### PR TITLE
fix(flyout): mirror flyout placement for right-to-left targets

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
@@ -877,7 +877,8 @@ public class Given_FlowDirection
 	[DataRow(FlyoutPlacementMode.BottomEdgeAlignedLeft, FlowDirection.RightToLeft)]
 	public async Task When_Flyout_Placement_Is_Horizontal(FlyoutPlacementMode placement, FlowDirection flowDirection)
 	{
-		// Placements are relative to the target's flow direction: "left" is the leading side, which is the right in right-to-left.
+		// The side the flyout opens on follows the target's flow direction (Left opens on the right in right-to-left),
+		// but edge alignments like BottomEdgeAlignedLeft stay physical, matching WinUI.
 		var content = new Border { Width = 80, Height = 40, Background = new SolidColorBrush(Colors.Red) };
 		var flyout = new Flyout { Content = content, Placement = placement };
 		var target = new Button { Content = "Target", Width = 200, Height = 60, FlowDirection = flowDirection, Flyout = flyout, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
@@ -913,15 +914,7 @@ public class Given_FlowDirection
 			else
 			{
 				Assert.IsTrue(bounds.Top >= targetBounds.Bottom - 1, $"Expected the flyout ({bounds}) below the target ({targetBounds}).");
-
-				if (isRightToLeft)
-				{
-					Assert.AreEqual(targetBounds.Right, bounds.Right, 2, "Expected the flyout to be aligned with the target's leading (right) edge.");
-				}
-				else
-				{
-					Assert.AreEqual(targetBounds.Left, bounds.Left, 2, "Expected the flyout to be aligned with the target's leading (left) edge.");
-				}
+				Assert.AreEqual(targetBounds.Left, bounds.Left, 2, "Expected the flyout to be aligned with the target's physical left edge regardless of flow direction.");
 			}
 		}
 		finally

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
@@ -818,4 +818,115 @@ public class Given_FlowDirection
 			flyout.Hide();
 		}
 	}
+
+	private static Rect GetVisualBounds(FrameworkElement element)
+		=> element.TransformToVisual(null).TransformBounds(new Rect(0, 0, element.ActualWidth, element.ActualHeight));
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	[DataRow(FlowDirection.LeftToRight)]
+	[DataRow(FlowDirection.RightToLeft)]
+	public async Task When_MenuFlyout_Shown_At_Point(FlowDirection flowDirection)
+	{
+		// A menu opens towards the trailing side of its point: to the right in left-to-right, to the left in right-to-left.
+		var target = new Border { Width = 200, Height = 200, Background = new SolidColorBrush(Colors.LightGray), FlowDirection = flowDirection };
+		var root = new Grid { Width = 600, Height = 400, Children = { target } };
+		var flyout = new MenuFlyout { Items = { new MenuFlyoutItem { Text = "First item" }, new MenuFlyoutItem { Text = "Second item" } } };
+
+		TestServices.WindowHelper.WindowContent = root;
+		await TestServices.WindowHelper.WaitForLoaded(root);
+
+		var position = new Point(60, 40);
+		flyout.ShowAt(target, new FlyoutShowOptions { Position = position });
+
+		try
+		{
+			var item = (MenuFlyoutItem)flyout.Items[0];
+			await TestServices.WindowHelper.WaitForLoaded(item);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = item.FindFirstParent<MenuFlyoutPresenter>();
+			Assert.IsNotNull(presenter);
+			var bounds = GetVisualBounds(presenter);
+			var expectedPoint = target.TransformToVisual(null).TransformPoint(position);
+
+			Assert.AreEqual(expectedPoint.Y, bounds.Top, 2, "The menu should open below the point.");
+
+			if (flowDirection is FlowDirection.LeftToRight)
+			{
+				Assert.AreEqual(expectedPoint.X, bounds.Left, 2, "The menu should open towards the right of the point.");
+			}
+			else
+			{
+				Assert.AreEqual(expectedPoint.X, bounds.Right, 2, "The menu should open towards the left of the point.");
+			}
+		}
+		finally
+		{
+			flyout.Hide();
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	[DataRow(FlyoutPlacementMode.Left, FlowDirection.LeftToRight)]
+	[DataRow(FlyoutPlacementMode.Left, FlowDirection.RightToLeft)]
+	[DataRow(FlyoutPlacementMode.BottomEdgeAlignedLeft, FlowDirection.LeftToRight)]
+	[DataRow(FlyoutPlacementMode.BottomEdgeAlignedLeft, FlowDirection.RightToLeft)]
+	public async Task When_Flyout_Placement_Is_Horizontal(FlyoutPlacementMode placement, FlowDirection flowDirection)
+	{
+		// Placements are relative to the target's flow direction: "left" is the leading side, which is the right in right-to-left.
+		var content = new Border { Width = 80, Height = 40, Background = new SolidColorBrush(Colors.Red) };
+		var flyout = new Flyout { Content = content, Placement = placement };
+		var target = new Button { Content = "Target", Width = 200, Height = 60, FlowDirection = flowDirection, Flyout = flyout, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+		var root = new Grid { Width = 600, Height = 400, Children = { target } };
+
+		TestServices.WindowHelper.WindowContent = root;
+		await TestServices.WindowHelper.WaitForLoaded(root);
+
+		flyout.ShowAt(target);
+
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(content);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = content.FindFirstParent<FlyoutPresenter>();
+			Assert.IsNotNull(presenter);
+			var bounds = GetVisualBounds(presenter);
+			var targetBounds = GetVisualBounds(target);
+			bool isRightToLeft = flowDirection is FlowDirection.RightToLeft;
+
+			if (placement is FlyoutPlacementMode.Left)
+			{
+				if (isRightToLeft)
+				{
+					Assert.IsTrue(bounds.Left >= targetBounds.Right - 1, $"Expected the flyout ({bounds}) on the right of the target ({targetBounds}).");
+				}
+				else
+				{
+					Assert.IsTrue(bounds.Right <= targetBounds.Left + 1, $"Expected the flyout ({bounds}) on the left of the target ({targetBounds}).");
+				}
+			}
+			else
+			{
+				Assert.IsTrue(bounds.Top >= targetBounds.Bottom - 1, $"Expected the flyout ({bounds}) below the target ({targetBounds}).");
+
+				if (isRightToLeft)
+				{
+					Assert.AreEqual(targetBounds.Right, bounds.Right, 2, "Expected the flyout to be aligned with the target's leading (right) edge.");
+				}
+				else
+				{
+					Assert.AreEqual(targetBounds.Left, bounds.Left, 2, "Expected the flyout to be aligned with the target's leading (left) edge.");
+				}
+			}
+		}
+		finally
+		{
+			flyout.Hide();
+		}
+	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Private.Infrastructure;
+using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
@@ -693,5 +694,128 @@ public class Given_FlowDirection
 
 		var redTransformToRoot = (MatrixTransform)red.TransformToVisual(null);
 		Assert.AreEqual($"-0.5,0,0,0.5,{m31},{m32}", redTransformToRoot.Matrix.ToString());
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Flyout_Opened_From_RTL_Target()
+	{
+		// The flow direction of the placement target is forwarded to the popup and presenter (WinUI: ForwardPopupFlowDirection /
+		// ForwardTargetPropertiesToPresenter), so flyout content is laid out right-to-left when the target is.
+		var first = new Border { Width = 40, Height = 20, Background = new SolidColorBrush(Colors.Red) };
+		var second = new Border { Width = 40, Height = 20, Background = new SolidColorBrush(Colors.Green) };
+		var content = new StackPanel { Orientation = Orientation.Horizontal, Children = { first, second } };
+		var flyout = new Flyout { Content = content };
+		var button = new Button
+		{
+			Content = "Open",
+			FlowDirection = FlowDirection.RightToLeft,
+			Flyout = flyout,
+			HorizontalAlignment = HorizontalAlignment.Center,
+			VerticalAlignment = VerticalAlignment.Center,
+		};
+		var root = new Grid { Children = { button } };
+
+		TestServices.WindowHelper.WindowContent = root;
+		await TestServices.WindowHelper.WaitForLoaded(root);
+
+		flyout.ShowAt(button);
+
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(content);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = content.FindFirstParent<FlyoutPresenter>();
+			Assert.IsNotNull(presenter);
+			Assert.AreEqual(FlowDirection.RightToLeft, presenter.FlowDirection);
+			Assert.AreEqual(FlowDirection.RightToLeft, content.FlowDirection);
+
+#if SUPPORTS_RTL
+			// The presenter is the element whose direction differs from its (popup panel) parent, so it is the one being mirrored.
+			Assert.IsFalse(presenter.GetFlowDirectionTransform().IsIdentity);
+#endif
+
+			// Mirrored layout: the first child ends up to the right of the second one.
+			var firstX = first.TransformToVisual(null).TransformPoint(new Point(0, 0)).X;
+			var secondX = second.TransformToVisual(null).TransformPoint(new Point(0, 0)).X;
+			Assert.IsTrue(firstX > secondX, $"Expected the first child ({firstX}) to be laid out to the right of the second one ({secondX}).");
+		}
+		finally
+		{
+			flyout.Hide();
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_MenuFlyout_Opened_From_RTL_Target()
+	{
+		var item = new MenuFlyoutItem { Text = "Item" };
+		var flyout = new MenuFlyout { Items = { item } };
+		var button = new Button
+		{
+			Content = "Open",
+			FlowDirection = FlowDirection.RightToLeft,
+			Flyout = flyout,
+			HorizontalAlignment = HorizontalAlignment.Center,
+			VerticalAlignment = VerticalAlignment.Center,
+		};
+		var root = new Grid { Children = { button } };
+
+		TestServices.WindowHelper.WindowContent = root;
+		await TestServices.WindowHelper.WaitForLoaded(root);
+
+		flyout.ShowAt(button);
+
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(item);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = item.FindFirstParent<MenuFlyoutPresenter>();
+			Assert.IsNotNull(presenter);
+			Assert.AreEqual(FlowDirection.RightToLeft, presenter.FlowDirection);
+			Assert.AreEqual(FlowDirection.RightToLeft, item.FlowDirection);
+		}
+		finally
+		{
+			flyout.Hide();
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Flyout_Opened_From_LTR_Target()
+	{
+		var content = new Border { Width = 40, Height = 20 };
+		var flyout = new Flyout { Content = content };
+		var button = new Button { Content = "Open", Flyout = flyout, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+		var root = new Grid { Children = { button } };
+
+		TestServices.WindowHelper.WindowContent = root;
+		await TestServices.WindowHelper.WaitForLoaded(root);
+
+		flyout.ShowAt(button);
+
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(content);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = content.FindFirstParent<FlyoutPresenter>();
+			Assert.IsNotNull(presenter);
+			Assert.AreEqual(FlowDirection.LeftToRight, presenter.FlowDirection);
+#if SUPPORTS_RTL
+			Assert.IsTrue(presenter.GetFlowDirectionTransform().IsIdentity);
+#endif
+		}
+		finally
+		{
+			flyout.Hide();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -73,9 +73,9 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		internal FlyoutPlacementMode EffectivePlacement => m_hasPlacementOverride ? m_placementOverride : Placement;
 
 		/// <summary>
-		/// Gets the effective placement for the given flow direction: horizontal placements (left/right sides and left/right edge
-		/// alignments) are reversed for right-to-left, since placements are relative to the flow direction while the popup is positioned
-		/// in left-to-right window coordinates (WinUI: GetEffectivePlacementMode).
+		/// Gets the effective placement for the given flow direction: the side the flyout opens on is reversed for right-to-left,
+		/// while edge alignments (the AlignedLeft/AlignedRight suffixes) stay physical, matching WinUI's GetEffectivePlacementMode
+		/// which only mirrors the major placement.
 		/// </summary>
 		internal FlyoutPlacementMode GetEffectivePlacement(FlowDirection flowDirection)
 			=> flowDirection is FlowDirection.RightToLeft ? MirrorPlacement(EffectivePlacement) : EffectivePlacement;
@@ -84,10 +84,6 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		{
 			FlyoutPlacementMode.Left => FlyoutPlacementMode.Right,
 			FlyoutPlacementMode.Right => FlyoutPlacementMode.Left,
-			FlyoutPlacementMode.TopEdgeAlignedLeft => FlyoutPlacementMode.TopEdgeAlignedRight,
-			FlyoutPlacementMode.TopEdgeAlignedRight => FlyoutPlacementMode.TopEdgeAlignedLeft,
-			FlyoutPlacementMode.BottomEdgeAlignedLeft => FlyoutPlacementMode.BottomEdgeAlignedRight,
-			FlyoutPlacementMode.BottomEdgeAlignedRight => FlyoutPlacementMode.BottomEdgeAlignedLeft,
 			FlyoutPlacementMode.LeftEdgeAlignedTop => FlyoutPlacementMode.RightEdgeAlignedTop,
 			FlyoutPlacementMode.LeftEdgeAlignedBottom => FlyoutPlacementMode.RightEdgeAlignedBottom,
 			FlyoutPlacementMode.RightEdgeAlignedTop => FlyoutPlacementMode.LeftEdgeAlignedTop,

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -537,6 +537,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			}
 
 			ForwardTargetPropertiesToPresenter();
+			ForwardPopupFlowDirection();
 
 			// Capture the input device that triggered this flyout (mirrors WinUI ValidateAndSetParameters)
 			var contentRoot = VisualTree.GetContentRootForElement(placementTarget);
@@ -724,14 +725,33 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		}
 
 		/// <summary>
-		/// Forwards DataContext and theme from the placement target to the presenter.
+		/// Forwards the placement target's flow direction to the popup so that the flyout content is laid out (and mirrored) like the target.
+		/// Ported from WinUI: FlyoutBase_partial.cpp ForwardPopupFlowDirection.
+		/// </summary>
+		private void ForwardPopupFlowDirection()
+		{
+			if (_popup is not null)
+			{
+				// The popup is reused across openings, so a missing target resets the direction rather than keeping the previous target's.
+				_popup.FlowDirection = Target?.FlowDirection ?? FlowDirection.LeftToRight;
+			}
+		}
+
+		/// <summary>
+		/// Forwards DataContext, flow direction and theme from the placement target to the presenter.
 		/// Ported from WinUI: FlyoutBase_partial.cpp ForwardTargetPropertiesToPresenter.
 		/// </summary>
 		private void ForwardTargetPropertiesToPresenter()
 		{
-			if (_popup?.Child is FrameworkElement presenter && Target is { } target)
+			if (_popup?.Child is FrameworkElement presenter)
 			{
-				presenter.DataContext = target.DataContext;
+				if (Target is { } target)
+				{
+					presenter.DataContext = target.DataContext;
+				}
+
+				// The presenter is reused across openings, so a missing target resets the direction rather than keeping the previous target's.
+				presenter.FlowDirection = Target?.FlowDirection ?? FlowDirection.LeftToRight;
 			}
 
 			ForwardThemeToPresenter();

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -72,6 +72,29 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 
 		internal FlyoutPlacementMode EffectivePlacement => m_hasPlacementOverride ? m_placementOverride : Placement;
 
+		/// <summary>
+		/// Gets the effective placement for the given flow direction: horizontal placements (left/right sides and left/right edge
+		/// alignments) are reversed for right-to-left, since placements are relative to the flow direction while the popup is positioned
+		/// in left-to-right window coordinates (WinUI: GetEffectivePlacementMode).
+		/// </summary>
+		internal FlyoutPlacementMode GetEffectivePlacement(FlowDirection flowDirection)
+			=> flowDirection is FlowDirection.RightToLeft ? MirrorPlacement(EffectivePlacement) : EffectivePlacement;
+
+		private static FlyoutPlacementMode MirrorPlacement(FlyoutPlacementMode placement) => placement switch
+		{
+			FlyoutPlacementMode.Left => FlyoutPlacementMode.Right,
+			FlyoutPlacementMode.Right => FlyoutPlacementMode.Left,
+			FlyoutPlacementMode.TopEdgeAlignedLeft => FlyoutPlacementMode.TopEdgeAlignedRight,
+			FlyoutPlacementMode.TopEdgeAlignedRight => FlyoutPlacementMode.TopEdgeAlignedLeft,
+			FlyoutPlacementMode.BottomEdgeAlignedLeft => FlyoutPlacementMode.BottomEdgeAlignedRight,
+			FlyoutPlacementMode.BottomEdgeAlignedRight => FlyoutPlacementMode.BottomEdgeAlignedLeft,
+			FlyoutPlacementMode.LeftEdgeAlignedTop => FlyoutPlacementMode.RightEdgeAlignedTop,
+			FlyoutPlacementMode.LeftEdgeAlignedBottom => FlyoutPlacementMode.RightEdgeAlignedBottom,
+			FlyoutPlacementMode.RightEdgeAlignedTop => FlyoutPlacementMode.LeftEdgeAlignedTop,
+			FlyoutPlacementMode.RightEdgeAlignedBottom => FlyoutPlacementMode.LeftEdgeAlignedBottom,
+			_ => placement,
+		};
+
 		protected FlyoutBase()
 		{
 		}
@@ -589,7 +612,9 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 				}
 			}
 
-			_popup.DesiredPlacement = EffectivePlacement switch
+			// Placements are expressed relative to the target's flow direction, so horizontal ones are reversed for right-to-left targets
+			// (WinUI: GetEffectivePlacementMode). The popup panel positions the popup in left-to-right window coordinates.
+			_popup.DesiredPlacement = GetEffectivePlacement(placementTarget?.FlowDirection ?? FlowDirection.LeftToRight) switch
 			{
 				FlyoutPlacementMode.Top => PopupPlacementMode.Top,
 				FlyoutPlacementMode.Bottom => PopupPlacementMode.Bottom,
@@ -994,8 +1019,6 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			double maxWidth = double.NaN;
 			double maxHeight = double.NaN;
 			FrameworkElement spPopupAsFE;
-			FlowDirection flowDirection = FlowDirection.LeftToRight;
-			//FlowDirection targetFlowDirection = FlowDirection.LeftToRight;
 			bool isMenuFlyout = this is MenuFlyout;
 			bool preferTopPlacement = false;
 
@@ -1005,7 +1028,12 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			horizontalOffset = m_targetPoint.X;
 			verticalOffset = m_targetPoint.Y;
 
-			FlyoutPlacementMode placementMode = EffectivePlacement;
+			// Uno: unlike WinUI, which computes positioned flyouts in a coordinate space that is mirrored for right-to-left, the target
+			// point and the presenter rect are in left-to-right window coordinates here. Right-to-left is accounted for by reversing the
+			// horizontal placements and by opening menus towards the left of their point.
+			FlowDirection flowDirection = _popup.FlowDirection;
+			bool isRightToLeft = flowDirection is FlowDirection.RightToLeft;
+			FlyoutPlacementMode placementMode = GetEffectivePlacement(flowDirection);
 
 			// We want to preserve existing MenuFlyout behavior - it will continue to ignore the Placement property.
 			// We also don't want to adjust anything if we've been positioned for a DatePicker or TimePicker -
@@ -1047,6 +1075,12 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 						horizontalOffset -= presenterSize.Width;
 						break;
 				}
+			}
+
+			if (isMenuFlyout && isRightToLeft)
+			{
+				// In right-to-left the point is the trailing (right) edge of a menu, which opens towards the left.
+				horizontalOffset -= presenterSize.Width;
 			}
 
 			preferTopPlacement = (m_inputDeviceTypeUsedToOpen == InputDeviceType.Touch) && isMenuFlyout;
@@ -1208,55 +1242,31 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 				//(m_tpPresenter as Control.put_MaxHeight(
 				//	double.IsNaN(maxHeight) ? availableWindowRect.Height : Math.Min(maxHeight, availableWindowRect.Height)));
 
-				if (flowDirection == FlowDirection.LeftToRight)
+				// Adjust the target position if the current target is out of the Xaml window bounds
+				if (horizontalOffset + presenterSize.Width > availableWindowRect.X + availableWindowRect.Width)
 				{
-					// Adjust the target position if the current target is out of the Xaml window bounds
-					if (horizontalOffset + presenterSize.Width > availableWindowRect.X + availableWindowRect.Width)
+					if (m_isPositionedAtPoint)
 					{
-						if (m_isPositionedAtPoint)
-						{
-							// Update the target horizontal position if the target is out of the available rect
-							horizontalOffset -= Math.Min(presenterSize.Width, horizontalOffset);
-						}
-						else
-						{
-							// Used for date and time picker flyouts
-							horizontalOffset = availableWindowRect.X + availableWindowRect.Width - presenterSize.Width;
-							horizontalOffset = Math.Max(availableWindowRect.X, horizontalOffset);
-						}
+						// Update the target horizontal position if the target is out of the available rect
+						horizontalOffset -= Math.Min(presenterSize.Width, horizontalOffset);
+					}
+					else
+					{
+						// Used for date and time picker flyouts
+						horizontalOffset = availableWindowRect.X + availableWindowRect.Width - presenterSize.Width;
 					}
 				}
-				else
+				else if (horizontalOffset < availableWindowRect.X)
 				{
-					// Adjust the target position if the current target is out of the Xaml window bounds
-					if (horizontalOffset - presenterSize.Width < availableWindowRect.X)
+					if (m_isPositionedAtPoint)
 					{
-						if (m_isPositionedAtPoint)
-						{
-							// Update the target horizontal position if the target is out of the available rect
-							horizontalOffset += Math.Min(presenterSize.Width, (availableWindowRect.Width + availableWindowRect.X - horizontalOffset));
-						}
-						else
-						{
-							// Used for date and time picker flyouts
-							horizontalOffset = presenterSize.Width + availableWindowRect.X;
-							horizontalOffset = Math.Min(availableWindowRect.Width + availableWindowRect.X, horizontalOffset);
-						}
+						// Open towards the other side of the point when the presenter does not fit on this side (e.g. a right-to-left menu
+						// opened close to the left edge of the window).
+						horizontalOffset += Math.Min(presenterSize.Width, availableWindowRect.X + availableWindowRect.Width - (horizontalOffset + presenterSize.Width));
 					}
 				}
 
-				//// If we couldn't actually fit to the left, flip back to show right.
-				//if (shiftLeftForRightHandedness)
-				//{
-				//	if (!isRTL && horizontalOffset < availableWindowRect.X)
-				//	{
-				//		horizontalOffset += presenterSize.Width;
-				//	}
-				//	else if (isRTL && horizontalOffset + presenterSize.Width >= availableWindowRect.Width)
-				//	{
-				//		horizontalOffset -= presenterSize.Width;
-				//	}
-				//}
+				horizontalOffset = Math.Max(availableWindowRect.X, horizontalOffset);
 
 				// If opening up would cause the flyout to get clipped, we fall back to opening down:
 				if (preferTopPlacement && verticalOffset < availableWindowRect.Y)
@@ -1289,9 +1299,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 				//m_tpPopup.VerticalOffset = verticalOffset;
 			}
 
-			double leftMostEdge = (flowDirection == FlowDirection.LeftToRight) ? horizontalOffset : horizontalOffset - presenterSize.Width;
-
-			presenterRect.X = leftMostEdge;
+			presenterRect.X = horizontalOffset;
 			presenterRect.Y = verticalOffset;
 			presenterRect.Width = presenterSize.Width;
 			presenterRect.Height = presenterSize.Height;

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -127,7 +127,9 @@ namespace Microsoft.UI.Xaml
 			{
 				if (parent is FrameworkElement feParent)
 				{
-					return feParent is not PopupPanel && fe.FlowDirection != feParent.FlowDirection;
+					// The popup panel covers the whole window and positions its child in absolute coordinates, so it never mirrors itself;
+					// popup content (whose flow direction is forwarded from the flyout's placement target) mirrors relative to the panel.
+					return fe is not PopupPanel && fe.FlowDirection != feParent.FlowDirection;
 				}
 
 				parent = VisualTreeHelper.GetParent(parent);


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/24422 (follow-up)

_Stacked on #24425, which it needs for the popup's forwarded `FlowDirection`; the first commit is that PR._

## PR Type:

🐞 Bugfix

## What changed? 🚀

Follow-up to #24425. With the flyout content now laid out right-to-left, its *placement* still behaved as in left-to-right on Skia:

- A `Flyout` with `Placement="Left"` on a right-to-left target opened on the visual left, while placements are relative to the target's flow direction (WinUI reverses left and right for RTL in `GetEffectivePlacementMode`). Likewise the `LeftEdgeAligned*` and `RightEdgeAligned*` placements opened on the wrong side.
- A `MenuFlyout` shown at a point (or a context menu) opened towards the right of the point instead of towards the left.

WinUI handles this by computing positioned flyouts in a coordinate space that is mirrored for right-to-left. Uno's popup panel positions popups in left-to-right window coordinates, so instead of porting that math this PR reverses the side that horizontal placements open on for right-to-left targets (both for anchored flyouts, through the popup's `DesiredPlacement`, and for positioned ones in `UpdateTargetPosition`), opens right-to-left menus towards the left of their point, and clamps to the window bounds in visual coordinates on both sides. Edge alignments such as `BottomEdgeAlignedLeft` keep aligning with the physical edge of the target, matching WinUI, which only mirrors the major placement side. The `UpdateTargetPosition` port had a hard-coded `LeftToRight` direction and a dead right-to-left branch written for the mirrored coordinate space; both are replaced.

Runtime tests cover a `MenuFlyout` shown at a point and `Left` / `BottomEdgeAlignedLeft` placements for both flow directions.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
