### PR TITLE
docs: Document system accent color support

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -33,6 +33,20 @@ For details, see [Vulkan Rendering Backend](xref:Uno.Skia.Vulkan).
 
 Set `Uno.UI.FeatureConfiguration.Rendering.SkipVisualTreePainting` to `true` to skip painting of the visual tree entirely, producing frames with no visual output. Frame scheduling, rendering events, composition animations and `RenderTargetBitmap` keep working as usual. This is intended for scenarios where the visual output is of no interest (e.g. automated tests) to save CPU/GPU. Default: `false`.
 
+## Accent color
+
+### Overriding the system accent color
+
+By default, the `SystemAccentColor` theme resources and `UISettings.GetColorValue(UIColorType.Accent)` follow the accent color of the operating system, see [View Management](xref:Uno.Features.WinUIViewManagement). To force a specific accent regardless of the OS, for example to enforce a brand color or to get deterministic screenshots in tests, set `Uno.UI.FeatureConfiguration.AccentColor.OverrideAccentColor` before the UI is created, typically in the `App` constructor:
+
+```csharp
+#if HAS_UNO
+Uno.UI.FeatureConfiguration.AccentColor.OverrideAccentColor = Windows.UI.Color.FromArgb(0xFF, 0x10, 0x7C, 0x10);
+#endif
+```
+
+The lighter and darker shades are derived from the color you provide. Set the property back to `null` to follow the operating system again. Changing the override at runtime raises `UISettings.ColorValuesChanged` and updates `{ThemeResource}` references to the accent resources.
+
 ## ComboBox
 
 ### Default preferred placement

--- a/doc/articles/features/using-skia-desktop.md
+++ b/doc/articles/features/using-skia-desktop.md
@@ -118,6 +118,8 @@ When running using X11 Wayland compatibility (e.g. recent Ubuntu releases), DPI 
 
 The X11 support uses DBus for various interactions with the system, such as file selection. Make sure that dbus is installed.
 
+System appearance settings are read from the [XDG desktop portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html) (`org.freedesktop.portal.Settings`) over the session bus: the light or dark theme, the high contrast mode, the text scaling factor and the [system accent color](windows-ui-viewmanagement.md#system-accent-color). The portal is normally installed and started by the desktop environment (`xdg-desktop-portal` plus a backend such as `xdg-desktop-portal-gnome` or `xdg-desktop-portal-kde`). Each setting needs a backend that exposes it; the accent color requires version 2 of the Settings portal with the `accent-color` key, available on GNOME 47+ and KDE Plasma 6. When the session bus, the portal or the backend is not available, Uno Platform logs the failure and falls back to the defaults (light theme, default blue accent).
+
 ## .NET Native AOT support
 
 Building an Uno Platform Skia Desktop app with .NET (7+) Native AOT requires Uno Platform 4.7 (or later).

--- a/doc/articles/features/windows-ui-viewmanagement.md
+++ b/doc/articles/features/windows-ui-viewmanagement.md
@@ -43,4 +43,26 @@ If you don’t explicitly set the `ForegroundColor`, the app will automatically 
 
 Using the `GetColorValue` method, you can retrieve the system `Background` and `Foreground` color, which is useful to check if the system is currently using dark or light theme. To get notified about the color scheme changes, subscribe to the `ColorValuesChanged` event. Similarly to UWP, make sure to keep a reference to the `UISettings` instance, otherwise the instance will be collected and the event will not be raised.
 
+### System accent color
+
+`GetColorValue` also returns the system accent color and its variants: `UIColorType.Accent`, `AccentLight1` to `AccentLight3`, and `AccentDark1` to `AccentDark3`. The same values back the `SystemAccentColor`, `SystemAccentColorLight1` to `SystemAccentColorDark3` theme resources and the `SystemColorControlAccentBrush` brush used by the built-in control styles, so controls follow the accent color of the operating system without any code. See [Accent color palette](https://learn.microsoft.com/windows/apps/design/style/color#accent-color-palette) for the WinUI description of these values.
+
+| Platform | Accent color source | Live updates |
+|----------|---------------------|--------------|
+| Windows | Windows accent palette | ✔ |
+| Windows (Skia) | Windows accent palette (registry) | ✔ |
+| macOS (Skia) | System Settings → Appearance accent color | ✔ |
+| Linux (Skia, X11) | `accent-color` from the XDG Settings portal (GNOME 47+, KDE Plasma 6, or any backend implementing version 2 of `org.freedesktop.portal.Settings`) | ✔ |
+| Android | Material You dynamic colors (Android 12 and later) | Read at startup |
+| iOS, WebAssembly, Linux (framebuffer) | Not available, default palette | ✖ |
+
+When the platform does not expose an accent color, the default blue palette (`#0078D7`) is used. Windows exposes its full palette of seven shades; the other platforms expose a single color and Uno Platform derives the lighter and darker shades from it, so they can differ slightly from the shades Windows would produce for the same accent.
+
+`ColorValuesChanged` is raised when the accent color changes at runtime. `{ThemeResource}` references to the accent resources update automatically; as in WinUI, `{StaticResource}` references keep the value they resolved to.
+
+> [!NOTE]
+> On Linux, the accent color is read asynchronously from the desktop portal when the app starts, so the first frames use the default palette until the value arrives, and `{StaticResource}` references resolved during `OnLaunched` keep the default accent. See [X11 specifics](using-skia-desktop.md#x11-specifics) for the portal requirements.
+
+To force a specific accent color regardless of the operating system, set `Uno.UI.FeatureConfiguration.AccentColor.OverrideAccentColor`, see [Configuring Uno's behavior globally](../feature-flags.md#accent-color).
+
 On Android, the `AnimationsEnabled` property is implemented and allows you to check whether animations were disabled on the system level (for accessibility or battery saving). You can then use this information to disable custom animations within your app.


### PR DESCRIPTION
**GitHub Issue:** related to #4444 (documentation for the accent color feature; the issue is closed by #22851)

> **Stacked on #24424**, itself stacked on #22851. Documentation only; it should be rebased or retargeted once the code PRs merge.

## PR Type:

📚 Documentation content changes

## What changed? 🚀

#22851 makes `UISettings.GetColorValue(UIColorType.Accent*)`, the `SystemAccentColor*` theme resources and `SystemColorControlAccentBrush` follow the OS accent color, and adds `FeatureConfiguration.AccentColor.OverrideAccentColor`; #24424 adds the Linux (X11) implementation. Neither PR touches `doc/`, so the feature was undocumented. This PR adds:

- `doc/articles/features/windows-ui-viewmanagement.md`: a **System accent color** section under `UISettings` with the per-platform support table (source of the accent, live updates), the default-palette fallback, the single-color shade derivation caveat, `ColorValuesChanged` / `{ThemeResource}` vs `{StaticResource}` behaviour, the Linux startup note, and a pointer to the override flag.
- `doc/articles/feature-flags.md`: an **Accent color** section documenting `Uno.UI.FeatureConfiguration.AccentColor.OverrideAccentColor` with a snippet.
- `doc/articles/features/using-skia-desktop.md`, *X11 Specifics*: which appearance settings are read from the XDG Settings portal (theme, high contrast, text scaling, accent), the backend requirements (Settings v2 with `accent-color`: GNOME 47+, KDE Plasma 6), and the fallback behaviour when the bus, portal or backend is missing.

No new pages, so no `toc.yml` change. `markdownlint` (`build/.markdownlint.json`) and `cspell` (`build/cSpell.json`) pass on the three files.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, documentation only
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — N/A, documentation only
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
