### PR TITLE
feat(sdk): Allow overriding the Uno core package version

### DIFF
--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -141,6 +141,7 @@ Here are the supported properties:
 | `UnoThemesVersion`               | [Uno.Material.WinUI](https://www.nuget.org/packages/Uno.Material.WinUI) and similar packages                     | Supplies a variety of themes that can be applied to Uno Platform applications to enhance the UI.                                    |
 | `UnoToolkitVersion`              | [Uno.Toolkit.WinUI](https://www.nuget.org/packages/Uno.Toolkit.WinUI) and similar packages                       | Offers a collection of controls, helpers, and tools to complement the standard WinUI components.                                    |
 | `UnoUniversalImageLoaderVersion` | [Uno.UniversalImageLoader](https://www.nuget.org/packages/Uno.UniversalImageLoader)                              | Facilitates the loading and displaying of images across different platforms supported by Uno.                                       |
+| `UnoVersion`                     | [Uno.WinUI](https://www.nuget.org/packages/Uno.WinUI) and all other Uno Platform core packages                   | Overrides the version of the Uno Platform core packages. Defaults to the version bundled with the `Uno.Sdk`. See [Overriding the Uno Platform version](#overriding-the-uno-platform-version). |
 | `UnoWasmBootstrapVersion`        | [Uno.Wasm.Bootstrap](https://www.nuget.org/packages/Uno.Wasm.Bootstrap) and similar packages                     | Enables the bootstrapping of Uno Platform applications running on WebAssembly.                                                      |
 
 > [!NOTE]
@@ -210,6 +211,24 @@ Those properties can be set from `Directory.Build.props` or may be set in the `c
 ```
 
 In the sample above, we are overriding the default versions of the `UnoToolkit`, `MicrosoftLogging`, and `CommunityToolkitMvvm` packages.
+
+## Overriding the Uno Platform version
+
+The version of the Uno Platform core packages — `Uno.WinUI` and every package versioned alongside it, such as `Uno.WinUI.DevServer`, `Uno.WinUI.Graphics2DSK`, or the `Uno.WinUI.Runtime.Skia.*` packages — is normally determined by the `Uno.Sdk` version [set in `global.json`](xref:Uno.Development.UpgradeUnoNuget), so the SDK and the packages it references always match.
+
+Set the `UnoVersion` property to pin those packages to a different version, for instance to try a newer `Uno.WinUI` before the matching `Uno.Sdk` has been released:
+
+```xml
+<!-- Directory.Build.props or .csproj file -->
+<PropertyGroup>
+  <UnoVersion>6.4.0-dev.123</UnoVersion>
+</PropertyGroup>
+```
+
+The core packages always move together: `UnoVersion` repins all of them at once, as mixing versions between them is not a supported configuration.
+
+> [!WARNING]
+> A version that differs from the one bundled with the `Uno.Sdk` raises the [UNOB0004](xref:Build.Solution.error-codes) warning, as the combination is not tested and may fail to build or to run. Prefer updating the `Uno.Sdk` version in `global.json` whenever the version you need is available there. Once you have acknowledged the warning, silence it with `<NoWarn>$(NoWarn);UNOB0004</NoWarn>`.
 
 ## Using Central Package Management with implicit packages
 

--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -27,15 +27,17 @@ This error may occur during resources (`.resw`) analysis if the framework does n
 
 For instance, the language code `zh-CN` is not recognized and `zh-Hans` should be used instead.
 
-### UNOB0004: The $(UnoVersion) property must match the version of the Uno.Sdk defined in global.json
+### UNOB0004: The Uno Platform core packages are pinned to a version other than the one shipped by the Uno.Sdk
 
-The build process has determined that an MSBuild property was defined to override `UnoVersion`. This property is defined by the Uno.Sdk and cannot be changed and must be updated through the `global.json` file
+This warning indicates that the `$(UnoVersion)` property was set to a version that differs from the one bundled with the `Uno.Sdk` defined in `global.json`. The `Uno.Sdk` and the Uno Platform packages it references are built and tested together, so a mismatched pair may fail to build or to run.
 
-Follow this guide in order to [update the Uno Platform packages](xref:Uno.Development.UpgradeUnoNuget).
+Overriding the version is supported for scenarios such as validating a newer `Uno.WinUI` before the matching `Uno.Sdk` is published — see [Overriding the Uno Platform version](xref:Uno.Features.Uno.Sdk#overriding-the-uno-platform-version). Whenever the version you need is also available as an `Uno.Sdk`, prefer updating `global.json` instead, following this guide to [update the Uno Platform packages](xref:Uno.Development.UpgradeUnoNuget).
 
-### UNOB0005: The Version of Uno.WinUI must match the version of the Uno.Sdk found in global.json
+Once you have acknowledged the risk, silence the warning with `<NoWarn>$(NoWarn);UNOB0004</NoWarn>`.
 
-The build process has determined that the version of the Uno.WinUI NuGet package does not match the Uno.Sdk version. In general, restarting your IDE and compiling again will fix this issue.
+### UNOB0005: The Version of Uno.WinUI must match the Uno Platform version used by the build
+
+The build process has determined that the version of the resolved Uno.WinUI NuGet package does not match the requested Uno Platform version, which comes either from the `Uno.Sdk` in `global.json` or from the `$(UnoVersion)` property. In general, restarting your IDE and compiling again will fix this issue.
 
 Follow this guide in order to [update the Uno Platform packages](xref:Uno.Development.UpgradeUnoNuget).
 

--- a/src/Uno.Sdk/Services/PackageManifest.cs
+++ b/src/Uno.Sdk/Services/PackageManifest.cs
@@ -42,16 +42,18 @@ internal class PackageManifest
 		Manifest = new List<ManifestGroup>(_defaultManifest);
 
 		var unoVersion = GetGroupVersion(Group.Core);
-		if (unoVersion is null || string.IsNullOrEmpty(unoVersion))
+		if (string.IsNullOrEmpty(unoVersion))
 		{
 			// This should never happen.
 			throw new InvalidOperationException("No Uno Version was set.");
 		}
-
-		UnoVersion = unoVersion;
 	}
 
-	public string UnoVersion { get; }
+	/// <summary>
+	/// The version of the Uno Platform core packages, which defaults to the version bundled
+	/// with the Uno.Sdk and may be overridden through the $(UnoVersion) property.
+	/// </summary>
+	public string UnoVersion => GetGroupVersion(Group.Core);
 
 	public List<ManifestGroup> Manifest { get; private set; }
 
@@ -78,11 +80,6 @@ internal class PackageManifest
 
 	public PackageManifest UpdateManifest(string groupName, string? version)
 	{
-		if (groupName.Equals(Group.Core, StringComparison.InvariantCultureIgnoreCase))
-		{
-			throw new InvalidOperationException("You cannot override the Core Package group.");
-		}
-
 		if (!string.IsNullOrEmpty(version))
 		{
 			if (Manifest.Any(x => x.Group.Equals(groupName, StringComparison.InvariantCultureIgnoreCase)))

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -43,6 +43,8 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 	[Required]
 	public string ProjectName { get; set; } = null!;
 
+	public string? UnoVersion { get; set; }
+
 	public string? UnoExtensionsVersion { get; set; }
 
 	public string? UnoToolkitVersion { get; set; }
@@ -164,17 +166,19 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 			}
 
 			_manifest = new PackageManifest(Log, TargetFrameworkVersion);
+
+			// This needs to run before we get and Validate the Uno Features, and before the
+			// core version is read, as it may have been overridden through $(UnoVersion).
+			SetupRuntimePackageManifestUpdates(_manifest);
+
 			if (NuGetVersion.TryParse(_manifest.UnoVersion, out var unoVersion))
 			{
 				_unoVersion = unoVersion;
 			}
 			else
 			{
-				throw new InvalidOperationException("Unable to parse UnoVersion from the Package Manifest.");
+				throw new InvalidOperationException($"Unable to parse the Uno Platform version '{_manifest.UnoVersion}'.");
 			}
-
-			// This needs to run before we get and Validate the Uno Features
-			SetupRuntimePackageManifestUpdates(_manifest);
 
 			_unoFeatures = GetFeatures();
 			if (Log.HasLoggedErrors)
@@ -241,7 +245,10 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 		// Checks any MSBuild parameters passed to the task to override the default versions from the bundled packages.json
 		// This set of updates must not be conditional to features, as those may not be defined yet when the task
 		// is invoked early.
-		manifest.UpdateManifest(PackageManifest.Group.WasmBootstrap, UnoWasmBootstrapVersion)
+		// The Core group moves as a unit: $(UnoVersion) repins every Uno.WinUI* package together, as mixing
+		// core package versions is not a supported configuration.
+		manifest.UpdateManifest(PackageManifest.Group.Core, UnoVersion)
+			.UpdateManifest(PackageManifest.Group.WasmBootstrap, UnoWasmBootstrapVersion)
 			.UpdateManifest(PackageManifest.Group.OSLogging, UnoLoggingVersion)
 			.UpdateManifest(PackageManifest.Group.VlcNativeWindowsAssets, VlcNativeWindowsAssetsVersion)
 			.UpdateManifest(PackageManifest.Group.MicrosoftWebView2, MicrosoftWebView2Version)

--- a/src/Uno.Sdk/targets/Uno.Build.targets
+++ b/src/Uno.Sdk/targets/Uno.Build.targets
@@ -1,23 +1,26 @@
 <Project>
-	<!-- Uno Developers should comment this target out if they need to override UnoVersion for dev testing -->
 	<Target Name="UnoSdkVersionCheck"
 			AfterTargets="ResolveReferences"
-			BeforeTargets="BeforeBuild"
-			Condition="'$(PkgUno_WinUI)' != ''">
-		<Error Code="UNOB0004"
+			BeforeTargets="BeforeBuild">
+		<!--
+			$(UnoVersion) pins every Uno Platform core package. Setting it to a version other than the one
+			bundled with the Uno.Sdk is allowed, so that a newer Uno.WinUI can be tested before the matching
+			Uno.Sdk ships, but the combination is not tested and is reported as a warning.
+		-->
+		<Warning Code="UNOB0004"
 			HelpLink="https://aka.platform.uno/UNOB0004"
-			Text="The '%24(UnoVersion)' property must match the version of the Uno.Sdk defined in global.json (found $(UnoVersion) and expected DefaultUnoVersion). For more information about updating Uno Platform packages, visit https://aka.platform.uno/upgrade-uno-packages"
+			Text="The Uno Platform core packages are pinned to $(UnoVersion) through the '%24(UnoVersion)' property, while the Uno.Sdk defined in global.json ships DefaultUnoVersion. This combination is not tested and may fail to build or to run. Add UNOB0004 to '%24(NoWarn)' to silence this warning. For more information about updating Uno Platform packages, visit https://aka.platform.uno/upgrade-uno-packages"
 			Condition=" '$(UnoVersion)' != 'DefaultUnoVersion' " />
 
-		<!-- Check if the Uno.WinUI version matches DefaultUnoVersion -->
-		<PropertyGroup>
+		<!-- Check if the resolved Uno.WinUI version matches the requested core version -->
+		<PropertyGroup Condition=" '$(PkgUno_WinUI)' != '' ">
 			<_UnoSdkVersionCheck_Resolved_UnoWinUI>$([System.IO.Path]::GetFileName($(PkgUno_WinUI)))</_UnoSdkVersionCheck_Resolved_UnoWinUI>
 		</PropertyGroup>
 
 		<Error Code="UNOB0005"
 			HelpLink="https://aka.platform.uno/UNOB0005"
-			Text="The version of Uno.WinUI must match the version of the Uno.Sdk found in global.json (found $(_UnoSdkVersionCheck_Resolved_UnoWinUI) and expected DefaultUnoVersion). If the version was recently changed in global.json, make sure to restart your IDE. For more information about updating Uno Platform packages, visit https://aka.platform.uno/upgrade-uno-packages"
-			Condition="$(_UnoSdkVersionCheck_Resolved_UnoWinUI) != 'DefaultUnoVersion'" />
+			Text="The version of Uno.WinUI must match the Uno Platform version used by the build (found $(_UnoSdkVersionCheck_Resolved_UnoWinUI) and expected $(UnoVersion)). If the version was recently changed in global.json or through the '%24(UnoVersion)' property, make sure to restart your IDE. For more information about updating Uno Platform packages, visit https://aka.platform.uno/upgrade-uno-packages"
+			Condition=" '$(PkgUno_WinUI)' != '' AND '$(_UnoSdkVersionCheck_Resolved_UnoWinUI)' != '$(UnoVersion)' " />
 	</Target>
 
 	<!--

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.targets
@@ -43,6 +43,7 @@
 				PackageReferences="@(PackageReference)"
 				PackageVersions="@(PackageVersion)"
 				MauiVersion="$(MauiVersion)"
+				UnoVersion="$(UnoVersion)"
 				UnoExtensionsVersion="$(UnoExtensionsVersion)"
 				UnoToolkitVersion="$(UnoToolkitVersion)"
 				UnoThemesVersion="$(UnoThemesVersion)"


### PR DESCRIPTION
**GitHub Issue:** closes #24430

## PR Type:

✨ Feature

## What changed? 🚀

The `Core` package group was the only group in the `Uno.Sdk` package manifest with no override. `UnoToolkitVersion`, `UnoThemesVersion`, `WinAppSdkVersion` and roughly forty other groups each expose an MSBuild property, while `PackageManifest.UpdateManifest` explicitly threw `"You cannot override the Core Package group."`. An app could not move `Uno.WinUI` ahead of the `Uno.Sdk` pinned in `global.json` without taking over every core `PackageReference` by hand, or hitting mixed core package versions by overriding only `Uno.WinUI`.

`$(UnoVersion)` now repins the whole core group:

```xml
<PropertyGroup>
  <UnoVersion>6.7.103</UnoVersion>
</PropertyGroup>
```

The group moves as a unit — all 22 core packages (`Uno.WinUI`, `Uno.WinUI.DevServer`, `Uno.WinUI.Graphics2DSK`, the `Uno.WinUI.Runtime.Skia.*` family, …) take the same version, since mixing versions between them is not a supported configuration.

Changes by commit:

- **`feat(sdk): Allow overriding Uno core package version`** — routes `$(UnoVersion)` through `Uno.Implicit.Packages.targets` into the resolver and the manifest. The manifest's `UnoVersion` is now computed from the `Core` group rather than captured in the constructor, and the preview detection used for the NuGet version fallback is parsed *after* the manifest updates run, so both observe the overridden version.
- **`feat(sdk): Report core version override as UNOB0004`** — an override is untested rather than invalid, so `UNOB0004` becomes a suppressible warning naming both versions instead of an error.
- **`docs: Document the UnoVersion override`** — adds `UnoVersion` to the version property table, a dedicated section describing the override and its constraints, and rewrites the `UNOB0004` entry.

### Behavioral notes

`UnoSdkVersionCheck` was gated on `$(PkgUno_WinUI)`, a path property nothing in the SDK defines, so both `UNOB0004` and `UNOB0005` were effectively dormant unless an app opted into `GeneratePathProperty` itself. That condition moves onto `UNOB0005` — the check that actually needs the resolved package path — so the core version check now evaluates on every build. `UNOB0005` also compares the resolved `Uno.WinUI` against the effective version rather than the bundled one, so it no longer fires against a deliberate override.

One consequence worth flagging for review: a project that already sets `$(UnoVersion)` *and* builds with `TreatWarningsAsErrors` will now see a build failure where the check previously never ran. Adding `UNOB0004` to `$(NoWarn)` resolves it.

### Validation

There is no test project covering `ImplicitPackagesResolver` today, so this was validated against a locally packed `Uno.Sdk.Private 255.255.255-dev` (a version whose core packages do not exist on nuget.org, which makes the override observable):

| Scenario | Result |
|---|---|
| No override | Core packages resolve to `255.255.255-dev`; non-core groups unaffected; no `UNOB0004` |
| `-p:UnoVersion=6.2.0` | All core packages resolve to `6.2.0`; non-core groups unchanged |
| `UnoVersion` via `Directory.Build.props` | Same result, confirming the evaluation order against `Sdk.props` |
| `-p:UnoVersion=6.2.0` | `UNOB0004` warning raised, naming both versions |
| `-p:UnoVersion=6.2.0 -p:NoWarn=UNOB0004` | Warning suppressed |
| `dotnet restore -p:UnoVersion=6.7.103` | **Restore succeeds** |
| `dotnet restore` (no override) | **Fails** with `NU1102` on `Uno.WinUI` and the other core packages |

The last two are the fails-before / passes-after pair.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — validated manually as described above; the SDK resolver has no test project, and adding one is proposed as follow-up
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbASX5Bye8oXvMJ58xtfgs
