### PR TITLE
fix(xaml): Give ResourceResolver scopes thread affinity

### DIFF
--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceResolver_Scopes.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceResolver_Scopes.cs
@@ -1,0 +1,75 @@
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI;
+using Uno.UI.DataBinding;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml;
+
+[TestClass]
+public class Given_ResourceResolver_Scopes
+{
+	[TestMethod]
+	public async Task When_Parallel_Threads_Push_Distinct_Scopes_Each_Thread_Sees_Its_Own()
+	{
+		using var firstPushed = new ManualResetEventSlim();
+		using var secondPushed = new ManualResetEventSlim();
+		using var firstChecked = new ManualResetEventSlim();
+		var firstSource = new object();
+		var secondSource = new object();
+		var firstReference = WeakReferencePool.RentWeakReference(this, firstSource);
+		var secondReference = WeakReferencePool.RentWeakReference(this, secondSource);
+
+		try
+		{
+			var firstScope = XamlScope.Create().Push(firstReference);
+			var secondScope = XamlScope.Create().Push(secondReference);
+			Assert.AreNotEqual(firstScope, secondScope);
+
+			var first = Task.Run(() =>
+			{
+				ResourceResolver.PushNewScope(firstScope);
+				try
+				{
+					firstPushed.Set();
+					secondPushed.Wait();
+
+					// A shared process-wide stack exposes secondScope here, so this
+					// assertion fails before ResourceResolver scopes are thread-local.
+					Assert.AreEqual(firstScope, ResourceResolver.CurrentScope);
+				}
+				finally
+				{
+					ResourceResolver.PopScope();
+					firstChecked.Set();
+				}
+			});
+
+			var second = Task.Run(() =>
+			{
+				firstPushed.Wait();
+				ResourceResolver.PushNewScope(secondScope);
+				try
+				{
+					secondPushed.Set();
+					firstChecked.Wait();
+					Assert.AreEqual(secondScope, ResourceResolver.CurrentScope);
+				}
+				finally
+				{
+					ResourceResolver.PopScope();
+				}
+			});
+
+			await Task.WhenAll(first, second);
+		}
+		finally
+		{
+			WeakReferencePool.ReturnWeakReference(this, firstReference);
+			WeakReferencePool.ReturnWeakReference(this, secondReference);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -78,18 +78,27 @@ namespace Uno.UI
 
 		private static readonly Logger _log = typeof(ResourceResolver).Log();
 
-		private static readonly Stack<XamlScope> _scopeStack;
+		[ThreadStatic]
+		private static Stack<XamlScope> _scopeStack;
+
+		private static Stack<XamlScope> ScopeStack
+		{
+			get
+			{
+				if (_scopeStack is null)
+				{
+					_scopeStack = new Stack<XamlScope>();
+					_scopeStack.Push(XamlScope.Create());
+				}
+
+				return _scopeStack;
+			}
+		}
 
 		/// <summary>
 		/// The current xaml scope for resource resolution.
 		/// </summary>
-		internal static XamlScope CurrentScope => _scopeStack.Peek();
-
-		static ResourceResolver()
-		{
-			_scopeStack = new Stack<XamlScope>();
-			_scopeStack.Push(XamlScope.Create()); //There should always be a base-level scope (this will be used when no template is being resolved)
-		}
+		internal static XamlScope CurrentScope => ScopeStack.Peek();
 
 		/// <summary>
 		/// Performs a one-time, typed resolution of a named resource, using Application.Resources.
@@ -865,7 +874,7 @@ namespace Uno.UI
 		/// Push a new <see cref="XamlScope"/>, typically because a template is being materialized.
 		/// </summary>
 		/// <param name="scope"></param>
-		internal static void PushNewScope(XamlScope scope) => _scopeStack.Push(scope);
+		internal static void PushNewScope(XamlScope scope) => ScopeStack.Push(scope);
 		/// <summary>
 		/// Push a new Resources source to the current xaml scope.
 		/// </summary>
@@ -875,24 +884,27 @@ namespace Uno.UI
 		/// </summary>
 		internal static void PushSourceToScope(ManagedWeakReference source)
 		{
-			var current = _scopeStack.Pop();
-			_scopeStack.Push(current.Push(source));
+			var scopeStack = ScopeStack;
+			var current = scopeStack.Pop();
+			scopeStack.Push(current.Push(source));
 		}
 		/// <summary>
 		/// Pop Resources source from current xaml scope.
 		/// </summary>
 		internal static void PopSourceFromScope()
 		{
-			var current = _scopeStack.Pop();
-			_scopeStack.Push(current.Pop());
+			var scopeStack = ScopeStack;
+			var current = scopeStack.Pop();
+			scopeStack.Push(current.Pop());
 		}
 		/// <summary>
 		/// Pop current <see cref="XamlScope"/>, typically because template materialization is complete.
 		/// </summary>
 		internal static void PopScope()
 		{
-			_scopeStack.Pop();
-			if (_scopeStack.Count == 0)
+			var scopeStack = ScopeStack;
+			scopeStack.Pop();
+			if (scopeStack.Count == 0)
 			{
 				throw new InvalidOperationException("Base scope should never be popped.");
 			}


### PR DESCRIPTION
**GitHub Issue:** closes #24434

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

`ResourceResolver`'s XAML scope stack, used while materializing templates, was a single process-wide
`Stack<XamlScope>`. `PushNewScope` / `PopScope` / `PushSourceToScope` / `PopSourceFromScope` all mutated it, so two
threads materializing templates concurrently would push and pop each other's scopes and `CurrentScope` could return
the other thread's scope.

The stack is now `[ThreadStatic]`, with its base scope created lazily per thread.

**This is hardening, not a fix for an observed bug.** Resource resolution is expected to run on the UI thread today
and no in-product failure is known to depend on it. The motivation is that it matches DXAML, where the XAML core and
its scopes are per-thread, and it removes a footgun for future off-thread or multi-UI-thread work. Reviewers should
feel free to reject it on that basis.

Split out of #21513 so it can be judged on its own merits rather than riding along with the `Generic.xaml` import.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

`Given_ResourceResolver_Scopes` covers the interleaving. No docs change: internal behavior only, no public API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFELmYiNR7C7xmcmCR8BDq
