### PR TITLE
feat!: Raise minimum OS versions for 7.0

### DIFF
--- a/doc/articles/getting-started/requirements.md
+++ b/doc/articles/getting-started/requirements.md
@@ -19,23 +19,23 @@ Uno Platform runs in browsers that support WebAssembly, including Chromium-based
 Two paths are available:
 
 - Applications built with Uno Platform's [Skia Desktop](xref:Uno.Skia.Desktop) target framework, supporting Windows 7 and above, using the `net10.0-desktop` target framework.
-- Running apps built with WinAppSDK or WinUI run on Windows 10. Currently Uno.UI's API definition is aligned with [Windows 10 2004 (19041)](https://learn.microsoft.com/windows/uwp/whats-new/windows-10-build-19041), using the `net10.0-windows10.0.19041` target framework. Lower versions can be targeted.
+- Apps built with WinAppSDK or WinUI run on [Windows 10 2004 (19041)](https://learn.microsoft.com/windows/uwp/whats-new/windows-10-build-19041) and above, using the `net10.0-windows10.0.19041` target framework. Uno.UI's API definition is aligned with that build, and it is the default `TargetPlatformMinVersion`. Lower versions can be targeted explicitly, down to the Windows App SDK floor of Windows 10 1809 (17763).
 
 ## Android
 
-Uno Platform apps run on devices running Android 5 and above, using the `net10.0-android` target framework.
+Uno Platform apps run on devices running Android 7.0 (API 24) and above, using the `net10.0-android` target framework. API 24 is the minimum required by .NET 11, and Uno Platform applies the same floor on `net10.0-android`.
 
-At compile time, Uno Platform typically supports two versions of the Android SDK, the latest and the immediately previous (e.g. Android 15 and Android 14). It's generally recommended to use the latest version of the SDK.
+At compile time, Uno Platform typically supports two versions of the Android SDK, the latest and the immediately previous (e.g. Android 16 and Android 15). It's generally recommended to use the latest version of the SDK, and Google Play requires new apps and updates to target API 36 or higher.
 
 > [!NOTE]
-> This **does not** affect the runtime version. Apps compiled with Android 15 will run properly on devices running Android 10.
+> This **does not** affect the runtime version. Apps compiled against the Android 16 SDK will run properly on devices running Android 10.
 
 ## iOS
 
-Uno Platform apps run on iOS 11 and above, using the `net10.0-ios` target framework.
+Uno Platform apps run on iOS 15 and above, using the `net10.0-ios` target framework. tvOS 15 and above is supported through `net10.0-tvos`. iOS 15 is the oldest deployment target Xcode 27 — the toolchain .NET 11 builds with — will produce.
 
 > [!NOTE]
-> Using the Skia renderer on iOS 15.0 and above is recommended for optimal frame rate control. iOS 11-14 is supported with a legacy frame rate API.
+> The Skia renderer uses the iOS 15 frame-rate APIs on every supported version.
 
 ## macOS - Desktop
 

--- a/doc/articles/getting-started/requirements.md
+++ b/doc/articles/getting-started/requirements.md
@@ -19,7 +19,7 @@ Uno Platform runs in browsers that support WebAssembly, including Chromium-based
 Two paths are available:
 
 - Applications built with Uno Platform's [Skia Desktop](xref:Uno.Skia.Desktop) target framework, supporting Windows 7 and above, using the `net10.0-desktop` target framework.
-- Apps built with WinAppSDK or WinUI run on [Windows 10 2004 (19041)](https://learn.microsoft.com/windows/uwp/whats-new/windows-10-build-19041) and above, using the `net10.0-windows10.0.19041` target framework. Uno.UI's API definition is aligned with that build, and it is the default `TargetPlatformMinVersion`. Lower versions can be targeted explicitly, down to the Windows App SDK floor of Windows 10 1809 (17763).
+- Apps built with WinAppSDK or WinUI run on [Windows 10 2004 (19041)](https://learn.microsoft.com/windows/uwp/whats-new/windows-10-build-19041) and above by default, using the `net10.0-windows10.0.19041` target framework. Uno.UI's API definition is aligned with that build, and it is the default `TargetPlatformMinVersion`. A lower `TargetPlatformMinVersion` can be set explicitly, down to the Windows App SDK floor of [Windows 10 1809 (17763)](https://learn.microsoft.com/windows/uwp/whats-new/windows-10-build-17763).
 
 ## Android
 

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -85,8 +85,8 @@ targets. These are the values the `Uno.Sdk` applies when a head does not set
 | Android | 21 on `net10.0-android`, 24 on `net11.0-android` | **24 on both** | .NET 11 requires API 24 (Android 7.0). 7.0 applies the same floor to `net10.0-android` so a single value covers every target framework. |
 | WinAppSDK | `10.0.18362.0` | **`10.0.19041.0`** | Windows 10 1903 is out of support and is not listed as a supported OS for the Windows App SDK. 19041 matches the `windows10.0.19041.0` target framework already used throughout. |
 
-The Android Wear floor is unchanged at API 26, and the `net*-desktop` and
-`net*-browserwasm` targets remain ungated.
+The Android Wear floor is unchanged at API 26, and no minimum OS version is enforced
+for the `net*-desktop` and `net*-browserwasm` targets.
 
 A head that sets these properties explicitly keeps its own value, so an app can still
 target lower versions where the underlying SDK allows it — but those combinations are no

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -72,6 +72,26 @@ on macOS with Skia rendering. To migrate:
 5. Publish with the [macOS desktop packaging](xref:uno.publishing.desktop.macos) flow
    instead of the Mac Catalyst one.
 
+### Minimum OS versions raised
+
+Uno Platform 7.0 raises the default minimum OS version on the mobile and WinAppSDK
+targets. These are the values the `Uno.Sdk` applies when a head does not set
+`SupportedOSPlatformVersion` / `TargetPlatformMinVersion` itself.
+
+| Target | 6.x | 7.0 | Why |
+|---|---|---|---|
+| iOS | 14.2 | **15.0** | Xcode 27 — the toolchain .NET 11 builds with — refuses deployment targets below iOS 15. |
+| tvOS | 14.2 | **15.0** | Same Xcode 27 floor. |
+| Android | 21 on `net10.0-android`, 24 on `net11.0-android` | **24 on both** | .NET 11 requires API 24 (Android 7.0). 7.0 applies the same floor to `net10.0-android` so a single value covers every target framework. |
+| WinAppSDK | `10.0.18362.0` | **`10.0.19041.0`** | Windows 10 1903 is out of support and is not listed as a supported OS for the Windows App SDK. 19041 matches the `windows10.0.19041.0` target framework already used throughout. |
+
+The Android Wear floor is unchanged at API 26, and the `net*-desktop` and
+`net*-browserwasm` targets remain ungated.
+
+A head that sets these properties explicitly keeps its own value, so an app can still
+target lower versions where the underlying SDK allows it — but those combinations are no
+longer tested by Uno Platform.
+
 ### Packages
 
 | Removed / changed | Migration |
@@ -765,7 +785,10 @@ New apps get Skia heads only. Existing apps should drop native `*.Mobile` / nati
 12. Update assembly-qualified type names that reach MRT Core (`Microsoft.Windows.ApplicationModel.Resources.*`) — the assembly is now `Uno.WinRT`, not `Uno.UI`.
 13. Retype `Window.VisibilityChanged` handlers to `WindowVisibilityChangedEventArgs`, and drop
    any explicit `Window*EventHandler` delegate construction.
-14. Re-baseline visual/snapshot tests and re-test text, lists/scroll, IME, pickers, and
+14. Raise `SupportedOSPlatformVersion` to **15.0** (iOS/tvOS) and **24.0** (Android), and
+   `TargetPlatformMinVersion` to **10.0.19041.0** (WinAppSDK), in any head that pins them
+   explicitly.
+15. Re-baseline visual/snapshot tests and re-test text, lists/scroll, IME, pickers, and
    safe-area/notch handling on devices.
 
 See the [Uno 6.0 migration guide](xref:Uno.Development.MigratingToUno6#optional-use-of-skia-rendering-for-ios-android-and-webassembly)

--- a/src/SamplesApp/SamplesApp/Platforms/iOS/Info.plist
+++ b/src/SamplesApp/SamplesApp/Platforms/iOS/Info.plist
@@ -9,7 +9,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>13.0</string>
+	<string>15.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/src/SamplesApp/SamplesApp/Platforms/tvOS/Info.plist
+++ b/src/SamplesApp/SamplesApp/Platforms/tvOS/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>uno.platform.samplesapp.skia</string>
 	<key>MinimumOSVersion</key>
-	<string>13.0</string>
+	<string>15.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>

--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -336,8 +336,8 @@
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(_IsUIKit)' == 'true'">
-		<!-- 13.0 is the floor the .NET 11 iOS/tvOS SDKs enforce -->
-		<SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
+		<!-- Xcode 27 (.NET 11) refuses deployment targets below 15.0 -->
+		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
 		<!-- iOS 17 compatibility -->
 		<MtouchExtraArgs>$(MtouchExtraArgs) --weak-framework=NewsstandKit</MtouchExtraArgs>
 		<!-- AOT currently fails (uno-private #648): interpret instead -->
@@ -489,7 +489,7 @@
 
 	<!-- ==================== Windows build configuration ==================== -->
 	<PropertyGroup Condition="'$(_Platform)' == 'windows'">
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
 		<UseWinUI>true</UseWinUI>
 		<EnableMsixTooling>true</EnableMsixTooling>
 		<DefineConstants>$(DefineConstants);WINAPPSDK</DefineConstants>

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Mobile/UnoAppWinUI.Mobile.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Mobile/UnoAppWinUI.Mobile.csproj
@@ -17,7 +17,7 @@
     <ApplicationVersion>1</ApplicationVersion>
     <AndroidManifest>Android\AndroidManifest.xml</AndroidManifest>
     <IsUnoHead>true</IsUnoHead>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net11.0-ios'">26.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net11.0-ios'">15.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net11.0-android'">24.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)'==''">

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI/UnoAppWinUI.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI/UnoAppWinUI.csproj
@@ -13,7 +13,7 @@
 
 		<RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -86,6 +86,7 @@
 
 	<PropertyGroup Condition="$(IsAppleUIKit)">
 		<DefineConstants>$(DefineConstants);__APPLE_UIKIT__</DefineConstants>
+		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(IsAndroid)">

--- a/src/Uno.Sdk/targets/Uno.Common.Android.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Android.targets
@@ -3,8 +3,7 @@
 		<IsAndroid>true</IsAndroid>
 		<!-- androidx.wear.protolayout (Xamarin.AndroidX.Wear.Tiles) requires minSdk 26 -->
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' AND $(UnoFeatures.Contains(';androidwear;')) ">26.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' And $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0')) ">24.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">24.0</SupportedOSPlatformVersion>
 		<EnableDefaultAndroidItems Condition="$(EnableDefaultAndroidItems) == ''">false</EnableDefaultAndroidItems>
 
 		<AndroidManifest Condition=" $(AndroidManifest) == '' AND $(_IsUnoSingleProjectAndLegacy) == 'true' AND Exists('$(AndroidProjectFolder)AndroidManifest.xml') ">$(AndroidProjectFolder)AndroidManifest.xml</AndroidManifest>

--- a/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<IsWinAppSdk>true</IsWinAppSdk>
 		<UseRidGraph>true</UseRidGraph>
-		<TargetPlatformMinVersion Condition=" $(TargetPlatformMinVersion) == '' ">10.0.18362.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion Condition=" $(TargetPlatformMinVersion) == '' ">10.0.19041.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
 
 		<!-- Set EnableMsixTooling to true only for executables - setting this on class libraries prevents assets from being correctly copied to windows target -->

--- a/src/Uno.Sdk/targets/Uno.Common.iOS.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.iOS.targets
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<IsIOS>true</IsIOS>
-		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">15.0</SupportedOSPlatformVersion>
 
 		<EnableDefaultiOSItems Condition="$(EnableDefaultiOSItems) == ''">false</EnableDefaultiOSItems>
 

--- a/src/Uno.Sdk/targets/Uno.Common.tvOS.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.tvOS.targets
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<IsAppleUIKit>true</IsAppleUIKit>
 		<IsTvOS>true</IsTvOS>
-		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">15.0</SupportedOSPlatformVersion>
 
 		<EnableDefaulttvOSItems Condition="$(EnableDefaulttvOSItems) == ''">false</EnableDefaulttvOSItems>
 


### PR DESCRIPTION
**GitHub Issue:** closes #24441

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Raises the default minimum OS versions to a single coherent set, and aligns the places that disagreed with each other.

| Target | Before | After | Why |
|---|---|---|---|
| iOS | 14.2 | **15.0** | Xcode 27, the toolchain .NET 11 builds with, refuses deployment targets below iOS 15. |
| tvOS | 14.2 | **15.0** | Same Xcode 27 floor. |
| Android | 21 on `net10.0-android`, 24 on `net11.0-android` | **24 on both** | API 24 is the minimum required by .NET 11; the same floor is applied to `net10.0-android` so one value covers every target framework. |
| WinAppSDK | `10.0.18362.0` | **`10.0.19041.0`** | Windows 10 1903 is out of support and is not a supported OS for the Windows App SDK. 19041 matches the `windows10.0.19041.0` target framework already used throughout. |

Where the changes land:

- **`Uno.Sdk` defaults** — `Uno.Common.iOS.targets`, `Uno.Common.tvOS.targets`, `Uno.Common.Android.targets` (the per-TFM 21/24 split collapses to a single 24.0), `Uno.Common.WinAppSdk.targets`.
- **The framework itself** — `Uno.CrossTargetting.targets` now pins iOS/tvOS to 15.0 for Uno's own assemblies, matching the Android pin that was already there.
- **SamplesApp** — the UIKit heads move to 15.0 (both `Info.plist` files too), and the Windows head's `TargetPlatformMinVersion` goes from `10.0.17763.0` to `10.0.19041.0`; it was inconsistent with its own `windows10.0.19041.0` target framework.
- **Solution templates** — `UnoAppWinUI` moves iOS to 15.0, and `UnoAppWinUI.Mobile` is corrected from `26.0` (which required an iOS 26 device) to 15.0.
- **Docs** — a new *Minimum OS versions raised* section with the rationale table and a checklist entry in the 7.0 migration guide, and the iOS / Android / Windows App SDK sections of `requirements.md` corrected — they still documented "iOS 11 and above" and "Android 5 and above".

The Android Wear floor is unchanged at API 26, and the `net*-desktop` and `net*-browserwasm` targets stay ungated.

**Validation:** this is a build-property-only change, so it has been reviewed by inspection and every modified XML file checked for well-formedness. It has not been compile-validated locally — the iOS/tvOS heads require macOS to build — so CI is the first real check.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, MSBuild property defaults with no runtime surface
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

### Breaking change

The default minimum OS versions are raised to **iOS 15.0**, **tvOS 15.0**, **Android API 24** and **Windows 10.0.19041.0**.

**Impact:** app heads that inherit the `Uno.Sdk` defaults will no longer deploy to devices below those versions. On iOS/tvOS this is forced by the toolchain — Xcode 27 will not produce a lower deployment target — and on Android by .NET 11, which requires API 24.

**Migration:** a head that sets `SupportedOSPlatformVersion` or `TargetPlatformMinVersion` explicitly keeps its own value, so an app can still target lower versions where the underlying SDK allows it. Heads that pin these properties should raise them to the new defaults; the 7.0 migration guide carries the table and a checklist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbASX5Bye8oXvMJ58xtfgs
