### PR TITLE
ci: Cut the biggest CI warning sources (338 -> ~45 on the build summary)

### DIFF
--- a/build/ci/templates/dotnet-install.yml
+++ b/build/ci/templates/dotnet-install.yml
@@ -4,10 +4,20 @@ parameters:
   haveCheckout: true
 
 steps:
-  - bash: |
-      rm global.json
+  - pwsh: |
       # The file is named _global.json to avoid being picked up by the UseDotnet@2 task
-      cp build/ci/${{ parameters.globalJsonSubdir }}/_global.json global.json
+      Copy-Item build/ci/${{ parameters.globalJsonSubdir }}/_global.json global.json -Force
+
+      # UseDotNet@2's useGlobalJson mode globs **/global.json across the whole checkout and warns
+      # once per file that carries no sdk.version -- which every src/SolutionTemplate global.json
+      # does, since they only pin Uno.Sdk.Private. Read the version here instead and install it by
+      # name, which also skips the repository-wide scan.
+      $sdkVersion = (Get-Content global.json -Raw | ConvertFrom-Json).sdk.version
+      if ([string]::IsNullOrWhiteSpace($sdkVersion)) {
+        throw "build/ci/${{ parameters.globalJsonSubdir }}/_global.json does not declare an sdk.version."
+      }
+      Write-Host "##vso[task.setvariable variable=GlobalJsonSdkVersion]$sdkVersion"
+      Write-Host "Pinned .NET SDK version: $sdkVersion"
     displayName: "Using .NET global.json from build/ci/${{ parameters.globalJsonSubdir }}"
     condition: ${{ eq(parameters.haveCheckout, true) }}
 
@@ -29,7 +39,8 @@ steps:
     condition: ${{ eq(parameters.haveCheckout, true) }}
     inputs:
       packageType: sdk
-      useGlobalJson: true
+      useGlobalJson: false
+      version: $(GlobalJsonSdkVersion)
       includePreviewVersions: true
       installationPath: $(DOTNET_INSTALL_DIR)
 

--- a/src/SamplesApp/SamplesApp.Samples/Microsoft/UI/Xaml/Controls/TabViewTests/TabViewItemsSourceTests.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft/UI/Xaml/Controls/TabViewTests/TabViewItemsSourceTests.xaml
@@ -28,11 +28,11 @@
         </muxc:TabView.TabStripHeader>
         <muxc:TabView.TabItemTemplate>
             <DataTemplate x:DataType="local:TabItemViewModel">
-                <muxc:TabViewItem Header="{x:Bind Header, Mode=OneWay}" IsClosable="False">
+                <muxc:TabViewItem Header="{x:Bind Header, Mode=OneTime}" IsClosable="False">
                     <Button
                         x:Name="ContentButton"
                         Margin="5"
-                        Content="{x:Bind Header, Mode=OneWay}" />
+                        Content="{x:Bind Header, Mode=OneTime}" />
                 </muxc:TabViewItem>
             </DataTemplate>
         </muxc:TabView.TabItemTemplate>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/ApplicationModel/Contacts/PickContact.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/ApplicationModel/Contacts/PickContact.xaml
@@ -71,7 +71,7 @@
                     <DataTemplate x:DataType="contacts:ContactPhone">
                         <Border
                             Padding="8"
-                            x:DefaultBindMode="OneWay"
+                            x:DefaultBindMode="OneTime"
                             BorderBrush="Black"
                             BorderThickness="1">
                             <StackPanel>
@@ -101,7 +101,7 @@
                     <DataTemplate x:DataType="contacts:ContactAddress">
                         <Border
                             Padding="8"
-                            x:DefaultBindMode="OneWay"
+                            x:DefaultBindMode="OneTime"
                             BorderBrush="Black"
                             BorderThickness="1">
                             <StackPanel>
@@ -147,7 +147,7 @@
                     <DataTemplate x:DataType="contacts:ContactEmail">
                         <Border
                             Padding="8"
-                            x:DefaultBindMode="OneWay"
+                            x:DefaultBindMode="OneTime"
                             BorderBrush="Black"
                             BorderThickness="1">
                             <StackPanel>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/Storage/Pickers/FileOpenPickerTests.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/Storage/Pickers/FileOpenPickerTests.xaml
@@ -70,23 +70,23 @@
                             Orientation="Vertical">
                             <TextBlock>
                                 <Run Text="Display name: " />
-                                <Run Text="{x:Bind DisplayName, Mode=OneWay}" />
+                                <Run Text="{x:Bind DisplayName, Mode=OneTime}" />
                             </TextBlock>
                             <TextBlock>
                                 <Run Text="Name: " />
-                                <Run Text="{x:Bind Name, Mode=OneWay}" />
+                                <Run Text="{x:Bind Name, Mode=OneTime}" />
                             </TextBlock>
                             <TextBlock>
                                 <Run Text="File type: " />
-                                <Run Text="{x:Bind FileType, Mode=OneWay}" />
+                                <Run Text="{x:Bind FileType, Mode=OneTime}" />
                             </TextBlock>
                             <TextBlock>
                                 <Run Text="Content type: " />
-                                <Run Text="{x:Bind ContentType, Mode=OneWay}" />
+                                <Run Text="{x:Bind ContentType, Mode=OneTime}" />
                             </TextBlock>
                             <TextBlock>
                                 <Run Text="File path: " />
-                                <Run Text="{x:Bind Path, Mode=OneWay}" />
+                                <Run Text="{x:Bind Path, Mode=OneTime}" />
                             </TextBlock>
                         </StackPanel>
                     </DataTemplate>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/Storage/StorageFolderOperationsTests.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/Storage/StorageFolderOperationsTests.xaml
@@ -13,12 +13,12 @@
     <Page.Resources>
         <DataTemplate x:Key="FolderItemTemplate" x:DataType="storage:IStorageFolder">
             <TextBlock>
-                <Run FontWeight="Bold" Text="{x:Bind Name}" />
+                <Run FontWeight="Bold" Text="{x:Bind Name, Mode=OneTime}" />
             </TextBlock>
         </DataTemplate>
         <DataTemplate x:Key="FileItemTemplate" x:DataType="storage:IStorageFile">
             <TextBlock>
-                <Run Text="{x:Bind Name}" />
+                <Run Text="{x:Bind Name, Mode=OneTime}" />
             </TextBlock>
         </DataTemplate>
     </Page.Resources>
@@ -60,7 +60,7 @@
                     </StackPanel>
                     <ListView
                         Height="300"
-                        ItemTemplateSelector="{x:Bind StorageItemListTemplateSelector}"
+                        ItemTemplateSelector="{x:Bind StorageItemListTemplateSelector, Mode=OneTime}"
                         ItemsSource="{x:Bind ViewModel.StorageItemList}" />
                     <TextBlock
                         Foreground="Red"

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/MarkupExtensionTests/MarkupExtension.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/MarkupExtensionTests/MarkupExtension.xaml
@@ -16,8 +16,8 @@
 
         <DataTemplate x:Key="MarkupDataTemplate" x:DataType="ex:EntityObject">
             <StackPanel>
-                <TextBlock FontSize="16" Text="{x:Bind StringProperty, Mode=OneWay}" />
-                <TextBlock FontSize="16" Text="{x:Bind IntProperty, Mode=OneWay}" />
+                <TextBlock FontSize="16" Text="{x:Bind StringProperty, Mode=OneTime}" />
+                <TextBlock FontSize="16" Text="{x:Bind IntProperty, Mode=OneTime}" />
 
                 <!--  Make a markup extension inside a DataTemplate generates correctly  -->
                 <TextBlock FontSize="16" Text="{ex:Simple TextValue={StaticResource ResourceString2}}" />

--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -473,26 +473,6 @@
 	<Import Condition="'$(_IsUIKit)' == 'true'" Project="..\..\Uno.UI.Runtime.Skia.AppleUIKit\build\*.Runtime.Skia.AppleUIKit.props" />
 	<Import Condition="'$(_IsUIKit)' == 'true'" Project="..\..\Uno.UI.Runtime.Skia.AppleUIKit\build\*.Runtime.Skia.AppleUIKit.targets" />
 
-	<!--
-	WASM + mobile: Uno.UI.Tasks.targets retargets the head's Content (the Uno.UI.RuntimeTests assets
-	and fonts) into the wasm ms-appx manifest, AndroidAssets and iOS/tvOS BundleResources. Referencing
-	the framework from source means it does not arrive transitively, so import it explicitly. Desktop
-	is excluded — it loads ms-appx straight from the flat output dir.
-	-->
-	<PropertyGroup Condition="'$(_IsSkiaTfm)' == 'true' AND '$(_Platform)' != 'desktop'">
-		<UnoUIMSBuildTasksPath>$(MSBuildThisFileDirectory)..\..\SourceGenerators\Uno.UI.Tasks\bin\$(Configuration)_Shadow</UnoUIMSBuildTasksPath>
-	</PropertyGroup>
-	<Import Project="..\..\SourceGenerators\Uno.UI.Tasks\Content\Uno.UI.Tasks.targets"
-	        Condition="'$(_IsSkiaTfm)' == 'true' AND '$(_Platform)' != 'desktop' AND '$(SkipUnoResourceGeneration)' == ''" />
-
-	<!--
-	Android needs AndroidResourcesGenerator to emit the DrawableHelper.SetDrawableResolver call —
-	without it every ms-appx local asset lookup throws "Drawable resources were not initialized" at
-	runtime.
-	-->
-	<Import Project="..\..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props"
-	        Condition="'$(_Platform)' == 'android'" />
-
 	<!-- ==================== Windows build configuration ==================== -->
 	<PropertyGroup Condition="'$(_Platform)' == 'windows'">
 		<TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
@@ -684,8 +664,16 @@
 		<CompilerVisibleProperty Include="SkipIcuDataInitializerGenerator" />
 	</ItemGroup>
 
-	<!-- The XAML and DependencyProperty generators, which the samples need on every Skia TFM. WinUI is
-	     excluded: it uses the real WinUI XAML compiler. -->
+	<!--
+	The XAML and DependencyProperty generators, which the samples need on every Skia TFM. WinUI is
+	excluded: it uses the real WinUI XAML compiler.
+
+	This import is also what brings in Uno.UI.Tasks.targets, which retargets the head's Content (the
+	Uno.UI.RuntimeTests assets and fonts) into the wasm ms-appx manifest, AndroidAssets and iOS/tvOS
+	BundleResources, and Uno.UI.SourceGenerators.props, which Android needs so AndroidResourcesGenerator
+	emits the DrawableHelper.SetDrawableResolver call. Referencing the framework from source means
+	neither arrives transitively.
+	-->
 	<Import Project="..\..\SourceGenerators\sourcegenerators.local.props" Condition="'$(_IsSkiaTfm)' == 'true'" />
 
 	<!-- Must stay below the Sdk.props import at the top: Directory.Build.props sets

--- a/src/Uno.HotReload/AssemblyInfo.cs
+++ b/src/Uno.HotReload/AssemblyInfo.cs
@@ -4,3 +4,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Uno.UI.SourceGenerators.Tests")]
 [assembly: InternalsVisibleTo("Uno.UI.RemoteControl.Server.Processors")]
 [assembly: InternalsVisibleTo("Uno.HotReload.Tests")]
+
+// The assembly has never been audited for CLS compliance and is consumed only from C#.
+// Declaring it explicitly is CA1014's documented resolution.
+[assembly: CLSCompliant(false)]

--- a/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
+++ b/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
@@ -66,10 +66,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Content Include="build/*.*">
-			<Pack>true</Pack>
-			<PackagePath>build</PackagePath>
-		</Content>
+		<!-- None rather than Content: the Android SDK rejects @(Content) with XA0101, and these are
+		     packaging inputs only. -->
+		<None Include="build/*.*" Pack="true" PackagePath="build" />
 	</ItemGroup>
 
 	<!--<Import Project="..\SourceGenerators\Uno.UI.Tasks\Content\Uno.UI.Tasks.targets" Condition="'$(SkipUnoResourceGeneration)' == '' " />-->

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/ExpectedExceptionAttribute.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/ExpectedExceptionAttribute.cs
@@ -7,5 +7,5 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 // This only provides the minimal API so that runtimetests.engine can work.
 public sealed class ExpectedExceptionAttribute : Attribute
 {
-    public Type? ExceptionType => null;
+	public Type? ExceptionType => null;
 }

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Program.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Program.cs
@@ -2,21 +2,22 @@ using System;
 using Uno.UI.Hosting;
 
 namespace UnoApp50.Skia.Gtk;
+
 public class Program
 {
-    [STAThread]
-    public static void Main(string[] args)
-    {
-        AppHead.InitializeLogging();
+	[STAThread]
+	public static void Main(string[] args)
+	{
+		AppHead.InitializeLogging();
 
-        var host = UnoPlatformHostBuilder.Create()
-            .App(() => new AppHead())
-            .UseX11()
-            .UseLinuxFrameBuffer()
-            .UseMacOS()
-            .UseWin32()
-            .Build();
+		var host = UnoPlatformHostBuilder.Create()
+			.App(() => new AppHead())
+			.UseX11()
+			.UseLinuxFrameBuffer()
+			.UseMacOS()
+			.UseWin32()
+			.Build();
 
-        host.Run();
-    }
+		host.Run();
+	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_FileAddUpdateRemove.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_FileAddUpdateRemove.cs
@@ -29,7 +29,8 @@ public class Given_FileAddUpdateRemove
 
 		Assert.IsNull(sut.Get(), "Type should not exists yet");
 
-		/* await using ==> Causes roslyn crash */ var update = await _HR.UpdateAsync([AddXaml(sut), AddCodeBehind(sut)], ct);
+		/* await using ==> Causes roslyn crash */
+		var update = await _HR.UpdateAsync([AddXaml(sut), AddCodeBehind(sut)], ct);
 
 		Assert.IsNotNull(sut.Get(), "Page should have been compiled and made available to the application");
 	}
@@ -42,7 +43,8 @@ public class Given_FileAddUpdateRemove
 
 		Assert.IsNull(sut.Get(), "Type should not exists yet");
 
-		/* await using ==> Causes roslyn crash */ var update = await _HR.UpdateAsync([AddXaml(sut), AddCodeBehind(sut)], ct);
+		/* await using ==> Causes roslyn crash */
+		var update = await _HR.UpdateAsync([AddXaml(sut), AddCodeBehind(sut)], ct);
 
 		Assert.IsNotNull(sut.Get(), "Page should have been compiled and made available to the library");
 	}
@@ -169,12 +171,15 @@ public class Given_FileAddUpdateRemove
 		Assert.IsNull(sut1.Get(), "First type should not exist yet");
 		Assert.IsNull(sut2.Get(), "Second type should not exist yet");
 
-		/* await using ==> Causes roslyn crash */ var update = await _HR.UpdateAsync([
+		/* await using ==> Causes roslyn crash */
+		var update = await _HR.UpdateAsync(
+		[
 			AddXaml(sut1),
 			AddCodeBehind(sut1),
 			AddXaml(sut2),
 			AddCodeBehind(sut2)
-		], ct);
+		],
+		ct);
 
 		Assert.IsNotNull(sut1.Get(), "First page should have been compiled");
 		Assert.IsNotNull(sut2.Get(), "Second page should have been compiled");
@@ -269,7 +274,7 @@ public class Given_FileAddUpdateRemove
 			IsCreateDeleteAllowed: true);
 
 	private static FileEdit AddXaml(DynamicType type)
-		=> new (
+		=> new(
 			type.FilePath + ".xaml",
 			OldText: null,
 			NewText: $$"""

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame.cs
@@ -37,12 +37,8 @@ public class Given_Frame : BaseTestClass
 
 		frame.Navigate(typeof(HR_Frame_Pages_Page1));
 
-		var message = new HR_Frame_Pages_Page1().CreateUpdateFileMessage(
-			originalText: FirstPageTextBlockOriginalText,
-			replacementText: FirstPageTextBlockChangedText);
-
 		// Check the initial text of the TextBlock
-		await frame.ValidateTextOnChildTextBlock(message.OldText);
+		await frame.ValidateTextOnChildTextBlock(FirstPageTextBlockOriginalText);
 	}
 
 	/// <summary>

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadInfo.cs
@@ -76,10 +76,10 @@ public class Given_HotReloadInfo : BaseTestClass
 		try
 		{
 			// Perform first replace
-			await client.TryUpdateFileAsync(new (file, "<!--place_holder-->", "<ToggleButton /><!--place_holder-->"), ct);
+			await client.TryUpdateFileAsync(new(file, "<!--place_holder-->", "<ToggleButton /><!--place_holder-->"), ct);
 
 			// Invoke HR that will **NOT** change anything
-			await client.TryUpdateFileAsync(new (file, "<!--place_holder-->", "<!--place_holder_no_changes-->"), ct);
+			await client.TryUpdateFileAsync(new(file, "<!--place_holder-->", "<!--place_holder_no_changes-->"), ct);
 
 			// This should cause https://github.com/dotnet/roslyn/issues/79898
 			// But as we produced changes in previous HR update (HRInfo), it should be fine.

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBlock.cs
@@ -120,7 +120,7 @@ public class Given_TextBlock : BaseTestClass
 			SecondPageTextBlockOriginalText + Environment.NewLine,
 			true)
 			.WithExtendedTimeouts(); // Required for CI
-		
+
 		try
 		{
 			await hr.UpdateFileAsync(req, ct);

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
@@ -18,7 +18,8 @@
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
 		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-		<NoWarn>$(NoWarn);CS1998;IDE0051;IDE0055;NU1903;MSB3277</NoWarn>
+		<!-- CS8619: https://github.com/unoplatform/uno.ui.runtimetests.engine/issues/174#issuecomment-2104088957 -->
+		<NoWarn>$(NoWarn);CS1998;CS8619;IDE0051;IDE0055;NU1903;MSB3277</NoWarn>
 	</PropertyGroup>
 
 	<Target Name="DisplayBasePath" BeforeTargets="BeforeBuild">

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRUnoLib/Uno.UI.RuntimeTests.HRUnoLib.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRUnoLib/Uno.UI.RuntimeTests.HRUnoLib.csproj
@@ -28,7 +28,8 @@
 		</UnoFeatures>
 
 		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-		<NoWarn>$(NoWarn);CS1998;IDE0051;IDE0055;NU1903;MSB3277</NoWarn>
+		<!-- CS8619: https://github.com/unoplatform/uno.ui.runtimetests.engine/issues/174#issuecomment-2104088957 -->
+		<NoWarn>$(NoWarn);CS1998;CS8619;IDE0051;IDE0055;NU1903;MSB3277</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_HotReloadWorkspace.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_HotReloadWorkspace.cs
@@ -187,7 +187,6 @@ public partial class Given_HotReloadWorkspace
 				"build",
 				$"-p:UnoRemoteControlPort={_remoteControlPort}",
 				$"-p:UnoRemoteControlHost=127.0.0.1",
-				$"-p:NoWarn=CS8619", // Workaround https://github.com/unoplatform/uno.ui.runtimetests.engine/issues/174#issuecomment-2104088957
 				"--configuration",
 
 				// Use the debug configuration so that remote control


### PR DESCRIPTION
**GitHub Issue:** #6670

<!-- Deliberately not `closes`: #6670 is the umbrella issue for CI warning cleanup and this
     PR is the first batch. The tail it does not cover is listed under "Left for follow-up". -->

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The last master CI run (build 232343) reports **338 warnings** on its Azure DevOps summary, and
**565 warning lines** across the raw job logs. This is the first batch of cleanup, taken largest
offender first.

Baseline was measured by downloading all 2235 step logs for that build and counting against the
task-level timeline records only — the job and stage logs concatenate their children, so counting
every log double-counts.

### 282 — `UseDotNet@2` scanning the whole checkout for `global.json`

83% of the warnings on the build summary were one message repeated six times in every job that
installs the SDK:

```
The global.json at path: '.../src/SolutionTemplate/5.3/uno53AppWithLib/global.json' has the wrong
format. ... Error while trying to read: %s
```

`useGlobalJson: true` makes the task glob `**/global.json` from the sources directory and warn once
for every file that declares no `sdk.version`. The six `src/SolutionTemplate/**/global.json` files
only pin `Uno.Sdk.Private`, so each of them warns, in every job, on every agent.

`dotnet-install.yml` already stages the root `global.json` from `build/ci/<subdir>/_global.json`, so
it knows exactly which SDK is wanted. It now reads `sdk.version` out of that file and passes it to
`UseDotNet@2` by name. The task installs the same SDK it resolved before and no longer walks the
23k-file checkout.

### 50 — `WMC1506` OneWay `x:Bind` with nothing to notify

The WinUI XAML compiler raises `WMC1506` when no step in a OneWay binding path raises change
notifications. Each site here binds a source that is assigned once and never mutated — the WinRT
`ContactPhone`/`ContactAddress`/`ContactEmail`/`StorageFile` snapshots, the POCO item view models,
and the `DataTemplateSelector` built in a page constructor — so `OneTime` is what they mean.

`When_xLoad_Order` is deliberately untouched: it drives `x:Load` through an explicit
`Bindings.Update()` call, which is the behaviour under test.

### 48 + 6 — a global `NoWarn` property voiding two projects' suppression lists

`Given_HotReloadWorkspace.BuildTestApp` passed `-p:NoWarn=CS8619`. A **global** MSBuild property
replaces the value a project sets rather than adding to it, so this silently discarded the whole
`NoWarn` list that `Uno.UI.RuntimeTests.HRApp.Skia.csproj` and `Uno.UI.RuntimeTests.HRUnoLib.csproj`
declare — and `UNO0008` from `src/Directory.Build.props` with it. Every hot-reload run therefore
reported the `IDE0055`/`IDE0051`/`UNO0008` diagnostics those projects suppress on purpose.

`CS8619` moves into the two csproj files, where it composes with `$(NoWarn)`. The HRApp sources are
also formatted properly so `IDE0055` has nothing to report either way, and one genuine `CS8604` is
fixed by asserting against the `const` the other five tests in the class already use.

### 39 — `MSB4011` duplicate imports in `SamplesApp.csproj`

The head imported `Uno.UI.Tasks.targets` and `Uno.UI.SourceGenerators.props` directly, and then
imported `sourcegenerators.local.props`, which imports both of them again. Both direct conditions
are strict subsets of the `local.props` one, so the second import was always ignored — with an
`MSB4011` per TFM. The direct imports are removed and the rationale they carried is folded into the
comment on the import that actually provides them.

### 16 — `XA0101` on the Skia Android runtime package

`build/*.*` is a packaging input, but declaring it as `@(Content)` makes the Android SDK raise
`@(Content) build action is not supported` once per props/targets file per TFM. `None` with
`Pack`/`PackagePath` is the idiom the same project already uses for `uno.png`.

### 16 — `CA1014` on `Uno.HotReload`

The one project that opts into `AnalysisMode=Recommended`, so the only one this fires on. The
assembly has never been audited for CLS compliance and is consumed only from C#, so it now declares
that explicitly — the rule's documented resolution.

### Net effect

| | Before | After |
|---|---:|---:|
| Warnings on the ADO build summary | 338 | ~45 |
| Warning lines in the raw job logs | 565 | ~108 |

### Left for follow-up

Deliberately out of scope here, because each needs a decision or real work rather than a cleanup:

- `XA4211`/`XA1006` (6) — raising the samples' `targetSdkVersion` from 36 to 37 pins the app to a
  **preview** Android API level, which is a behavioural decision.
- `MT7156` (16) — `Assets/theme-dark` and `Assets/theme-light` collapse onto one iOS/tvOS
  `LogicalName`, plus Resizetizer emitting both `x.png` and `x.scale-100.png`.
- `NU5128`/`NU5129` (18) — nuspec dependency groups not matching the `lib/` folders.
- `APPX1102` (12), `PRI263` (8), `APT2000` (8).
- 3 `WMC1506` in `When_xLoad_Order`, as described above.
- Agent-side noise: low disk space on the macOS pool, empty iOS/tvOS runtime-test artifacts,
  simulator boot timeouts. The empty-artifact warning may be masking a real staging gap and is worth
  investigating rather than silencing.

## Validation

No behavioural change is intended anywhere in this PR, so each item was checked against the tree it
came from rather than only compiled.

**`MSB4011`** — `msbuild /pp` output compared before and after for `net10.0-android`. Both carry the
same single copy of `Uno.UI.Tasks.targets` and `Uno.UI.SourceGenerators.props`, the same 307
`UsingTask` elements and the same `UnoResourcesGeneration`/`UnoAssetsGeneration` targets;
`UnoUIMSBuildTasksPath`, `ShouldRunGenerator`, `_UnoUnderlyingPlatform`, `_IsAndroid`,
`AssignTargetPathsDependsOn` and `_IsXamlTrimmingAvailable` all evaluate identically. The old tree
reproduces both warnings, the new one is silent.

**`XA0101`** — `Uno.UI.Runtime.Skia.Android` goes from 2 warnings to 0, and the packed
`Uno.WinUI.Runtime.Skia.Android.nupkg` entry list is identical before and after, with
`build/Uno.WinUI.Runtime.Skia.Android.props` and `.targets` still present.

**`CA1014`** — reproduced under `AnalysisMode=All`: raised at `HEAD`, absent with the fix.

**Hot reload** — `HRApp` and `HRUnoLib` build clean; re-adding `-p:NoWarn=CS8619` brings the
warnings straight back, which is the mechanism this PR removes.

**Builds** — `SamplesApp` `net10.0-android` and `net10.0-desktop` both succeed with 0 errors and no
`MSB4011`; the retargeted samples compile. `dotnet format whitespace --verify-no-changes` and
`dotnet xstyler -d src/SamplesApp -r -p` (1521/1521) both pass.

The `dotnet-install.yml` change is the one thing that cannot be exercised locally. The YAML parses,
the resulting `UseDotNet@2` inputs are the same shape as the `haveCheckout: false` task already in
that file, and the PowerShell that extracts the version was run against both
`build/ci/net10/_global.json` and `build/ci/net11/_global.json`. It needs a CI run to confirm.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, no behaviour change; the before/after evidence above stands in
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no user-facing surface changes
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFELmYiNR7C7xmcmCR8BDq
