### PR TITLE
fix(ci): Drop SourceLink package, use the SDK's

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -270,9 +270,9 @@
 				<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 			</PropertyGroup>
 			<!--
-			SourceLink itself is provided implicitly by the .NET SDK (Microsoft.NET.Sdk.SourceLink.props), so no
-			PackageReference is needed. Referencing one would suppress the SDK's copy and pin an older, unmaintained
-			Microsoft.Build.Tasks.Git.
+				SourceLink itself is provided implicitly by the .NET SDK (Microsoft.NET.Sdk.SourceLink.props), so no
+				PackageReference is needed. Referencing one would suppress the SDK's copy and pin an older, unmaintained
+				Microsoft.Build.Tasks.Git.
 			-->
 		</When>
 	</Choose>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -269,9 +269,11 @@
 				<!-- Optional: Include PDB in the built .nupkg -->
 				<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 			</PropertyGroup>
-			<ItemGroup>
-				<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-			</ItemGroup>
+			<!--
+			SourceLink itself is provided implicitly by the .NET SDK (Microsoft.NET.Sdk.SourceLink.props), so no
+			PackageReference is needed. Referencing one would suppress the SDK's copy and pin an older, unmaintained
+			Microsoft.Build.Tasks.Git.
+			-->
 		</When>
 	</Choose>
 


### PR DESCRIPTION
**GitHub Issue:** closes #24463

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Every CI build has been failing during restore since the advisory database refreshed on 2026-09-09:

```
error NU1902: Warning As Error: Package 'Microsoft.Build.Tasks.Git' 8.0.0 has a known moderate
severity vulnerability, https://github.com/advisories/GHSA-23fw-v26w-5fgq
```

It hit 17 projects and took down `Build - Native Binaries (macOS)`, `Tests - Unit Tests`, and every `WebAssembly Skia Runtime Tests` job — those last ones fail while building `Uno.NUnitTransformTool`, so they never reach a single test.

### Root cause

`src/Directory.Build.props` carried an explicit `PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0"`.

Since .NET SDK 8.0.100 the SDK ships SourceLink itself and imports it implicitly — but `Microsoft.NET.Sdk.SourceLink.props` skips that import whenever a `Microsoft.SourceLink.*` package is referenced:

```xml
<!-- Suppress implicit SourceLink inclusion if any Microsoft.SourceLink package is referenced. -->
<SuppressImplicitGitSourceLink Condition="'$(PkgMicrosoft_SourceLink_Common)' != ''">true</SuppressImplicitGitSourceLink>
```

So the reference was pushing the SDK's current copy aside and pinning the three-year-old 8.0.0 `Microsoft.Build.Tasks.Git` in its place.

There is no `8.0.1` to bump to — the package is now versioned with the SDK band (`10.0.x` / `11.0.x`), so bumping the `PackageReference` would just re-introduce the version skew the implicit import exists to avoid. Deleting it is the fix: the SDK's SourceLink takes over.

The surrounding `PropertyGroup` is untouched, so `PublishRepositoryUrl`, the `.pdb`-in-`.nupkg` setting, and the `EmbedUntrackedSources=false` workaround for [mono/linker#1409](https://github.com/mono/linker/issues/1409) all still apply.

### Validation

**Restore** — `Uno.NUnitTransformTool` in `Release`, red before / green after:

| | result |
|---|---|
| before | `error NU1902: … Microsoft.Build.Tasks.Git 8.0.0 …` |
| after | `Restored … (in 150 ms)` |

**Restore (full CI scope)** — `build/filters/Uno.UI-packages-reference.slnf` in `Release`, on the exact CI SDK (`11.0.100-preview.7.26381.103` from `build/ci/net11/_global.json`): clean, zero `NU190x`, zero errors.

**Compile** — `Uno.NUnitTransformTool` builds `Release` with 0 errors.

**SourceLink still works** — generated `obj/Release/Uno.NUnitTransformTool.sourcelink.json`:

```json
{"documents":{"D:\\Work\\uno\\…\\*":"https://raw.githubusercontent.com/unoplatform/uno/611bb279f91e55c89e51ec767746a21890461722/*"}}
```

and the evaluated properties:

```
PublishRepositoryUrl  = true
RepositoryUrl         = https://github.com/unoplatform/uno
EmbedUntrackedSources = false
```

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, build-system change; CI restore is the test
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jox2uQ5z5SLRqfrhGMg2ZX
