### PR TITLE
fix(samplesapp): Stamp the app version on CI builds

### DIFF
--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -764,4 +764,24 @@
 			<_NativeExecutableFrameworks Remove="System" />
 		</ItemGroup>
 	</Target>
+
+	<!--
+	Every CI build has to ship a distinct app version: App Store Connect rejects an upload whose
+	CFBundleVersion it has already seen under the same short version. The timestamp goes in the display
+	version rather than in the build number, so an NBGV height reset — which every version.json bump
+	causes — still yields a version pair Apple has not seen before.
+	-->
+	<Target Name="GenerateVersion"
+			BeforeTargets="BeforeBuild;_CompileAppManifest;_GetAndroidPackageName"
+			Condition="'$(NBGV_AssemblyInformationalVersion)' != ''">
+		<PropertyGroup>
+			<_VersionCode>$(NBGV_VersionHeight)</_VersionCode>
+			<_VersionCode Condition="'$(_VersionCode)' == ''">0</_VersionCode>
+			<_VersionCode Condition="'$(VersionCodeOffset)' != ''">$([MSBuild]::Add($(_VersionCode), $(VersionCodeOffset)))</_VersionCode>
+
+			<ApplicationDisplayVersion>$([System.DateTime]::Now.ToString(`yyMMddHHmm`)).$(_VersionCode)</ApplicationDisplayVersion>
+			<ApplicationVersion>$(_VersionCode)</ApplicationVersion>
+			<InformationalVersion>$(NBGV_AssemblyInformationalVersion)</InformationalVersion>
+		</PropertyGroup>
+	</Target>
 </Project>


### PR DESCRIPTION
**GitHub Issue:** closes #24467

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The `SamplesApp` head sets no `ApplicationVersion`/`ApplicationDisplayVersion`, and its iOS and tvOS `Info.plist` carry no `CFBundleVersion` keys, so every build falls back to the Apple SDK default of `1.0`. App Store Connect accepted the first TestFlight upload (build 232547, the #24388 merge) and has rejected every one since as a duplicate:

```
ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE
The bundle version must be higher than the previously uploaded version: '1.0'
```

The retired `SamplesApp.Skia.netcoremobile` head carried a `GenerateVersion` target that stamped the version ahead of manifest compilation; the head consolidation never picked it up. This restores it. The CI pipeline already exports the NBGV variables it reads (`gitversion-run.yml` → `gitversion.yml`), so only the consumer was missing — no pipeline change is needed.

The timestamp goes in the display version (`CFBundleShortVersionString`) rather than in the build number, so each upload is a version pair Apple has not seen, and an NBGV height reset — which every `version.json` bump causes — cannot hand Apple a lower `CFBundleVersion` than the build before it.

This also restores the Android `versionCode` stamping, which the same target fed via `_GetAndroidPackageName` and which was silently lost too (no store upload rejects it, so nothing failed).

### Validation

- **MSBuild target run** — the target text as committed, extracted verbatim into a probe project and executed with `-t:GenerateVersion -getProperty:...`:

  | Case | `ApplicationVersion` | `ApplicationDisplayVersion` |
  |---|---|---|
  | No NBGV vars (local dev build) | *(empty)* | *(empty)* |
  | `NBGV_VersionHeight=684` | `684` | `2609091657.684` |
  | + `VersionCodeOffset=1000` | `1684` | `2609091657.1684` |

  The first row is the negative control: the target stays inert on a local build, so the values demonstrably come from this target and nothing else.

- **Code review** — `BeforeTargets` wiring is a 1:1 restore of the previously-shipping target.
- **Not validated here:** the end-to-end TestFlight upload. The stage is gated on `refs/heads/master`, so it can only be proven once this merges.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A: CI-only MSBuild path, covered by the target-execution probe above
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A: no rendering change
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rf6NKQN26Ld8Ef4reZoeY3
