### PR TITLE
fix(tests): Time out a hung test instead of the whole shard

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -62,6 +62,11 @@ namespace Uno.UI.Samples.Tests
 		private readonly TimeSpan DefaultUnitTestTimeout = TimeSpan.FromSeconds(60);
 #endif
 
+		// Ceiling for a test body that declares no [Timeout]. Deliberately far above any real test
+		// — the shape parity tests measure ~77s on WebAssembly — because its only job is to turn a
+		// hung test into one named failure rather than a whole shard whose results are never written.
+		private static readonly TimeSpan DefaultTestMethodTimeout = TimeSpan.FromMinutes(5);
+
 #if !WINAPPSDK
 		private ApplicationView _applicationView;
 #endif
@@ -1013,27 +1018,26 @@ namespace Uno.UI.Samples.Tests
 								if (test.Method.ReturnType == typeof(Task))
 								{
 									var task = (Task)returnValue;
-									var timeout = GetTestTimeout(test);
-									if (timeout.HasValue)
+									var timeout = GetTestTimeout(test) ?? DefaultTestMethodTimeout;
+
+									using var timeoutCancellation = new CancellationTokenSource();
+									var timeoutTask = Task.Delay(timeout, timeoutCancellation.Token);
+
+									var resultingTask = await Task.WhenAny(task, timeoutTask);
+
+									if (resultingTask == timeoutTask)
 									{
-										var timeoutTask = Task.Delay(timeout.Value);
-
-										var resultingTask = await Task.WhenAny(task, timeoutTask);
-
-										if (resultingTask == timeoutTask)
-										{
-											throw new TimeoutException(
-												$"Test execution timed out after {timeout.Value}");
-										}
-
-										// Rethrow exception if failed OR task cancelled if task **internally** raised
-										// a TaskCancelledException (we don't provide any cancellation token).
-										await resultingTask;
+										throw new TimeoutException(
+											$"Test execution timed out after {timeout}");
 									}
-									else
-									{
-										await task;
-									}
+
+									// Release the timer, so the default timeout does not leave one pending
+									// per test for the remainder of the run.
+									timeoutCancellation.Cancel();
+
+									// Rethrow exception if failed OR task cancelled if task **internally** raised
+									// a TaskCancelledException (we don't provide any cancellation token).
+									await resultingTask;
 								}
 
 								var console = consoleRecorder?.GetContentAndReset();


### PR DESCRIPTION
**GitHub Issue:** closes #24471

## PR Type:

🐞 Bugfix

## What changed? 🚀

`UnitTestsControl` only bounded a test body when the method carried an explicit `[Timeout]`; the else branch was a bare `await task`. So one hung async test with no attribute was awaited forever, the results XML was never written, and the job died on the harness or job timeout instead — discarding **the whole shard**, including up to ~1750 results that had already passed and the name of the test that hung.

That makes it an amplifier: three unrelated WebAssembly failure mechanisms (the sample runner never registering, a mid-run hang, and heap exhaustion) all collapse into the same undiagnosable "no results file" symptom. It is also why failures inside timed-out jobs never reach any flakiness analysis — they contribute zero rows.

`[Timeout]` now overrides a default instead of being the only source of one. The single timeout path replaces the if/else, and the timer is cancelled once the test completes so a long default doesn't leave one pending per test for the rest of the run.

### Choosing the default

The existing `DefaultUnitTestTimeout` (60 s in Release, applied only to initialize/cleanup) was the obvious thing to reuse — and it would have broken CI. Measured per-test durations on healthy agents:

| platform | tests timed | p50 | p99 | max |
|---|---|---|---|---|
| Android Skia | 4736 | 0.1 s | 1.2–2.6 s | 34.1 s (`When_Polyline`) |
| WebAssembly Skia | 6039 | 0.03 s | ~3 s | **76.5 s** (`When_Line`) |

The shape-parity tests legitimately reach ~77 s on WebAssembly, so a 60 s default would have turned currently-green builds red. 5 minutes is ~4× the observed healthy maximum, which is ample for its actual job — converting an infinite hang into one named failure — while staying well inside the shard budget.

Durations were recovered from the per-test `Running test X()` lines in the published Android device logs and the WebAssembly job logs of build 232676.

### Known limitation

On single-threaded WebAssembly, a `Task.Delay` continuation cannot run if a test blocks the dispatcher **synchronously**. This fix covers async hangs, which is the common case; a synchronous block still needs a JS-side watchdog. Not addressed here.

## Validation

- **Compile**: `UnoIslandsSamplesApp.Skia` (which includes `SamplesApp.UnitTests.Shared`) builds with 0 errors on `net10.0`.
- **Code review**: `GetTestTimeout` still returns the `[Timeout]` value when present, so existing per-test timeouts are unchanged; only the previously-unbounded path gains a ceiling.
- Not yet exercised against a real hang in CI — the behaviour change is only observable when a test hangs, which is what this PR's CI run cannot deliberately produce.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, this is the test harness itself
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jox2uQ5z5SLRqfrhGMg2ZX
