### PR TITLE
fix: ItemsRepeater.StartBringIntoView() throws on the repeater itself

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -239,6 +239,50 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 		}
 #endif
 
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21421")]
+		public async Task When_StartBringIntoView_On_Repeater_Itself_Then_Scrolls_Into_View()
+		{
+			var sut = new ItemsRepeater
+			{
+				ItemsSource = Enumerable.Range(0, 10).Select(i => $"Item #{i}").ToArray(),
+			};
+
+			var scroller = new ScrollViewer
+			{
+				Width = 200,
+				Height = 200,
+				Content = new StackPanel
+				{
+					Children =
+					{
+						// Pushes the repeater below the viewport, so bringing it into view has to scroll.
+						new Border { Height = 400, Background = new SolidColorBrush(Colors.LightGray) },
+						sut,
+					}
+				}
+			};
+
+			TestServices.WindowHelper.WindowContent = scroller;
+			await TestServices.WindowHelper.WaitForLoaded(sut);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			scroller.VerticalOffset.Should().Be(0, "the repeater starts below the viewport");
+
+			// The repeater itself is args.TargetElement here -- not one of its children.
+			// On WinUI this reaches ItemsRepeater.OnBringIntoViewRequested too; it fails internally
+			// there, but the failure is swallowed by the routed event dispatch, so the request still
+			// bubbles to the scroller and the caller sees no exception.
+			sut.StartBringIntoView();
+
+			// StartBringIntoView() asks for an animated scroll, so the offset settles over several frames.
+			await UITestHelper.WaitFor(
+				() => scroller.VerticalOffset > 0,
+				timeoutMS: 3000,
+				message: "StartBringIntoView on the ItemsRepeater itself should scroll it into view");
+		}
+
 #if HAS_UNO
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -1051,7 +1051,33 @@ namespace Microsoft.UI.Xaml
 		/// </remarks>
 		private void InvokeClassHandler(RoutedEvent routedEvent, RoutedEventArgs args)
 		{
-			if (routedEvent == ContextRequestedEvent)
+			// WinUI dispatches the built-in OnXxx overrides through CEventManager::RaiseUIElementEvents /
+			// RaiseControlEvents, both of which drop the callback's HRESULT: a class handler that fails
+			// neither aborts the raise nor stops the event bubbling to the parents. Mirror that here so a
+			// failure inside a framework control cannot surface at the RaiseEvent() call site -- notably
+			// ItemsRepeater rejecting a BringIntoViewRequested that targets the repeater itself, which
+			// WinUI throws on too and swallows at exactly this point (uno#21421).
+			// Handlers registered by application code run through InvokeHandlers and still propagate.
+			try
+			{
+				InvokeClassHandlerCore(routedEvent, args);
+			}
+			catch (Exception error)
+			{
+				if (this.Log().IsEnabled(LogLevel.Error))
+				{
+					this.Log().LogError($"Class handler for {routedEvent.Name} on {GetType()} failed; continuing the event route.", error);
+				}
+			}
+		}
+
+		private void InvokeClassHandlerCore(RoutedEvent routedEvent, RoutedEventArgs args)
+		{
+			if (routedEvent == BringIntoViewRequestedEvent)
+			{
+				OnBringIntoViewRequested((BringIntoViewRequestedEventArgs)args);
+			}
+			else if (routedEvent == ContextRequestedEvent)
 			{
 				// WinUI: Class handler shows ContextFlyout if present
 				if (this is Control control)

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -53,9 +53,6 @@ namespace Microsoft.UI.Xaml
 		private bool _warnedAboutTranslation;
 #endif
 
-		private static readonly TypedEventHandler<UIElement, BringIntoViewRequestedEventArgs> OnBringIntoViewRequestedHandler =
-			(UIElement sender, BringIntoViewRequestedEventArgs args) => sender.OnBringIntoViewRequested(args);
-
 		private static readonly Type[] _bringIntoViewRequestedArgs = new[] { typeof(BringIntoViewRequestedEventArgs) };
 
 		private string _uid;
@@ -99,11 +96,6 @@ namespace Microsoft.UI.Xaml
 		/// <remarks>This differs from the XamlRoot be being true for the root element of a native Popup.</remarks>
 		internal bool IsVisualTreeRoot { get; set; }
 
-		private void Initialize()
-		{
-			SubscribeToOverridenRoutedEvents();
-		}
-
 #if SUPPORTS_RTL
 		internal Matrix3x2 GetFlowDirectionTransform()
 		{
@@ -138,20 +130,6 @@ namespace Microsoft.UI.Xaml
 			return false;
 		}
 #endif
-
-		private void SubscribeToOverridenRoutedEvents()
-		{
-			// Overridden Events are registered from constructor to ensure they are
-			// registered first in event handlers.
-			// https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.onpointerpressed#remarks
-
-			var implementedEvents = GetImplementedRoutedEvents();
-
-			if (implementedEvents.HasFlag(RoutedEventFlag.BringIntoViewRequested))
-			{
-				BringIntoViewRequested += OnBringIntoViewRequestedHandler;
-			}
-		}
 
 		internal RoutedEventFlag GetImplementedRoutedEvents()
 		{
@@ -1546,7 +1524,6 @@ namespace Microsoft.UI.Xaml
 		{
 			_isFrameworkElement = this is FrameworkElement;
 
-			Initialize();
 			InitializePointers();
 
 			UpdateHitTest();


### PR DESCRIPTION
**GitHub Issue:** closes #21421

## PR Type:

🐞 Bugfix

## What changed? 🚀

`ItemsRepeater.StartBringIntoView()` crashed:

```
InvalidOperationException: OnBringIntoViewRequested called with args.target element
not under the ItemsRepeater that recieved the call
  at ViewportManagerWithPlatformFeatures.GetImmediateChildOfRepeater(...)
  at ViewportManagerWithPlatformFeatures.OnBringIntoViewRequested(...)
  at ItemsRepeater.OnBringIntoViewRequested(...)
  at UIElement.RaiseEvent(...)
```

The repeater is a legitimate bring-into-view target, but `GetImmediateChildOfRepeater` walks *up* from `args.TargetElement` looking for an immediate child of the repeater — starting at the repeater it can never find one, so it throws.

### Why this is not a Repeater bug

Verified against native WinUI (WinAppSDK 2.4, blank app, an `ItemsRepeater` subclass logging around `base.OnBringIntoViewRequested`):

```
ProbeRepeater.OnBringIntoViewRequested CALLED, TargetElement is repeater=True
base.OnBringIntoViewRequested THREW System.Runtime.InteropServices.COMException (0x80004005):
  OnBringIntoViewRequested called with args.target element not under the ItemsRepeater that recieved the call
RESULT: StartBringIntoView did NOT throw
[event] scroller.BringIntoViewRequested ...      <- bubbling continued anyway
```

WinUI reaches the same code and throws the **same** error. It never surfaces because `CEventManager::RaiseUIElementEvents` and `RaiseControlEvents` discard the callback's `HRESULT`, and `CEventManager::Raise` is `void` — a failing class handler neither aborts the raise nor stops the bubble, so the caller sees nothing and the `ScrollViewer` still scrolls.

Uno diverged in how it dispatches the override: `UIElement.SubscribeToOverridenRoutedEvents` subscribed `OnBringIntoViewRequested` as an ordinary **instance** handler from the constructor, so it ran through `InvokeHandlers` and its exception escaped all the way out of `RaiseEvent`.

### The fix

- `OnBringIntoViewRequested` is now dispatched from `UIElement.InvokeClassHandler`, where WinUI dispatches it.
- A failing class handler is logged at `Error` and the event route continues, matching what WinUI's event manager does with the `HRESULT`.
- Handlers registered by application code still run through `InvokeHandlers` and **still propagate** — this does not reintroduce the input/dispatcher exception swallowing removed by #19197.

Fixing the routing layer rather than the Repeater keeps the ported `ViewportManagerWithPlatformFeatures` character-identical to its WinUI source, throw included, and covers the whole class of ported controls whose internal failures WinUI hides at this same point.

Dropping the subscription empties `UIElement.SubscribeToOverridenRoutedEvents` and `Initialize()`, so both are removed — which also drops a per-type reflection probe from every non-`Control` `UIElement` construction. `Control.SubscribeToOverridenRoutedEvents` and the generated `RoutedEventFlag` contract are untouched.

### Behaviour change (WinUI parity, worth a reviewer's eye)

Class handlers run before instance handlers and are **not** gated on `args.Handled`, so an `OnBringIntoViewRequested` override now also runs when the event was already handled by a descendant. That matches WinUI (`Raise` calls `RaiseUIElementEvents` before it ever looks at the handler list, with no handled check). `ScrollContentPresenter.OnBringIntoViewRequested` already guards on `args.Handled` itself, and the regression sweep below is green.

### Follow-up (not in this PR)

`Control.SubscribeToOverridenRoutedEvents` applies the same instance-handler shim to 26 input events (`PointerPressed`, `KeyDown`, `Tapped`, …) with 100+ overriders in `Uno.UI` alone. Migrating those to class handlers is the consistent next step, but it couples the handled-gating flip with an exception-propagation decision on the input path, so it deserves its own change and its own validation.

## Testing

`When_StartBringIntoView_On_Repeater_Itself_Then_Scrolls_Into_View` in `Given_ItemsRepeater` — an `ItemsRepeater` below a `ScrollViewer`'s viewport is asked to bring *itself* into view. Fails before the fix with the reported exception, passes after, and the scroller actually moves. It runs on the WinUI head too, where it also passes.

Runtime-validated on Skia Desktop — **62/62 passed, 0 failed** across `Given_ItemsRepeater`, `Given_PipsPager`, `ScrollPresenterBringIntoViewTests`, `ViewportTests` and the `ScrollViewer` suite.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes (no API change; see the WinUI-parity behaviour note above)
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmoGiAqxB74J2xwvHz2qqu
