### PR TITLE
ci: Cut the CI warning tail left by #24445 (43 -> 12 on the build summary)

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -185,25 +185,40 @@
 
 	<Target Name="BuildNuGetPackage" AfterTargets="Build" DependsOnTargets="PrepareBuildAssets" Condition="'$(BuildingInsideVisualStudio)'=='' and '$(Configuration)'=='Release'">
 		<PropertyGroup>
-			<!-- NU5123: Long paths - disabled as tragets in Uno.UI.Runtime.Skia.WebAssembly.Browser\buildTransitive have too long paths -->
-			<NuSpecProperties>NoWarn=NU5100,NU5105,NU5131;NU5123;branch=$(NBGV_BuildingRef);commitid=$(NBGV_GitCommitId)</NuSpecProperties>
+			<!--
+				NoWarn codes are comma-separated: a semicolon would end the property and drop the rest of the list.
+				NU5123: Long paths - disabled as tragets in Uno.UI.Runtime.Skia.WebAssembly.Browser\buildTransitive have too long paths
+			-->
+			<NuSpecNoWarn>NU5100,NU5105,NU5131,NU5123</NuSpecNoWarn>
+			<NuSpecProperties>branch=$(NBGV_BuildingRef);commitid=$(NBGV_GitCommitId)</NuSpecProperties>
 			<NuSpecProperties>$(NuSpecProperties);winuisourcepath=$(NetUWPOrWinUI);winuitargetpath=$(NetUWPOrWinUI)</NuSpecProperties>
 		</PropertyGroup>
+
+		<!--
+			Per-package NoWarn, so a code waived for one layout keeps reporting on the others:
+			- NU5129 (Uno.WinUI): buildTransitive holds helper targets that the per-TFM entry points import by
+			  relative path, so there is deliberately no buildTransitive\Uno.WinUI.targets to pair them with.
+			- NU5128 (Lottie, Svg): one netX.0 assembly serves every head, but the mobile heads need extra
+			  SkiaSharp native-asset dependencies, so those groups have no lib folder of their own.
+		-->
+		<ItemGroup>
+			<_NuSpecPackage Include="Uno.WinUI" NoWarn="$(NuSpecNoWarn),NU5129" />
+			<_NuSpecPackage Include="Uno.Foundation" NoWarn="$(NuSpecNoWarn)" />
+			<_NuSpecPackage Include="Uno.WinRT" NoWarn="$(NuSpecNoWarn)" />
+			<_NuSpecPackage Include="Uno.WinUI.Lottie" NoWarn="$(NuSpecNoWarn),NU5128" />
+			<_NuSpecPackage Include="Uno.WinUI.MSAL" NoWarn="$(NuSpecNoWarn)" />
+			<_NuSpecPackage Include="Uno.WinUI.Graphics2DSK" NoWarn="$(NuSpecNoWarn)" />
+			<_NuSpecPackage Include="Uno.WinUI.Svg" NoWarn="$(NuSpecNoWarn),NU5128" />
+			<_NuSpecPackage Include="Uno.WinUI.DevServer" NoWarn="$(NuSpecNoWarn)" />
+			<_NuSpecPackage Include="Uno.WinUI.XamlHost" NoWarn="$(NuSpecNoWarn)" />
+		</ItemGroup>
 
 		<!-- Pre-validation of contents to be packed -->
 		<Error Text="The Uno.UI.Extras PRI file is not present in src\Uno.UI.Extras\bin\Uno.UI.Extras.Windows\Release"
 					 Condition="!exists('..\src\Uno.UI.Extras\bin\Uno.UI.Extras.Windows\Release\$(NetUWPOrWinUI)\Uno.UI.Extras.pri')" />
 
 		<!-- Create the packages -->
-		<Exec Command="$(NuGetBin) pack nuget\Uno.WinUI.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
-		<Exec Command="$(NuGetBin) pack nuget\Uno.Foundation.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
-		<Exec Command="$(NuGetBin) pack nuget\Uno.WinRT.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
-		<Exec Command="$(NuGetBin) pack nuget\Uno.WinUI.Lottie.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
-		<Exec Command="$(NuGetBin) pack nuget\Uno.WinUI.MSAL.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
-		<Exec Command="$(NuGetBin) pack nuget\Uno.WinUI.Graphics2DSK.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
-		<Exec Command="$(NuGetBin) pack nuget\Uno.WinUI.Svg.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
-		<Exec Command="$(NuGetBin) pack nuget\Uno.WinUI.DevServer.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
-		<Exec Command="$(NuGetBin) pack nuget\Uno.WinUI.XamlHost.nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
+		<Exec Command="$(NuGetBin) pack nuget\%(_NuSpecPackage.Identity).nuspec -Verbosity Detailed -Version &quot;$(NBGV_SemVer2)&quot; -Properties &quot;NoWarn=%(_NuSpecPackage.NoWarn);$(NuSpecProperties)&quot;" />
 	</Target>
 
 	<!-- 7.0 is Skia-only: fail the pack if a native UI rendering head package is produced. -->

--- a/build/ci/tests/.azure-devops-tests-ios-runner.yml
+++ b/build/ci/tests/.azure-devops-tests-ios-runner.yml
@@ -155,21 +155,27 @@ jobs:
       # see https://github.com/unoplatform/uno/issues/6714
       failTaskOnFailedTests: true
 
-  - task: PublishTestResults@2
-    condition: always()
-    inputs:
-      testResultsFiles: '$(build.sourcesdirectory)/build/RuntimeTestResults*.xml'
-      testRunTitle: ${{ parameters.TestRunName }}
-      testResultsFormat: 'NUnit'
-      failTaskOnFailedTests: true
+  # Both outputs below come from the NUnit UI-test harness (SamplesApp.UITests), which the runtime
+  # kind never runs: ios-uitest-run.sh launches the app with simctl and polls for its own results
+  # file, which lands in TestResult-original.xml above. RuntimeTestResults*.xml and the screenshots
+  # under the staging directory therefore stay empty on a runtime job, and publishing them anyway
+  # only reports "no files found" / "directory is empty" on the build summary.
+  - ${{ if ne(parameters.TEST_KIND, 'runtime') }}:
+    - task: PublishTestResults@2
+      condition: always()
+      inputs:
+        testResultsFiles: '$(build.sourcesdirectory)/build/RuntimeTestResults*.xml'
+        testRunTitle: ${{ parameters.TestRunName }}
+        testResultsFormat: 'NUnit'
+        failTaskOnFailedTests: true
 
-  - task: PublishBuildArtifacts@1
-    condition: always()
-    retryCountOnTaskFailure: 10
-    inputs:
-      PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: ${{ parameters.TEST_KIND }}-tests-ios-${{ parameters.UITEST_VARIANT }}-results
-      ArtifactType: Container
+    - task: PublishBuildArtifacts@1
+      condition: always()
+      retryCountOnTaskFailure: 10
+      inputs:
+        PathtoPublish: $(build.artifactstagingdirectory)
+        ArtifactName: ${{ parameters.TEST_KIND }}-tests-ios-${{ parameters.UITEST_VARIANT }}-results
+        ArtifactType: Container
 
   # logs files are large, so we create them outside of `artifactstagingdirectory` and publish
   # them in a separate artifacts container.

--- a/build/ci/tests/.azure-devops-tests-tvos-runner.yml
+++ b/build/ci/tests/.azure-devops-tests-tvos-runner.yml
@@ -146,13 +146,17 @@ jobs:
       # see https://github.com/unoplatform/uno/issues/6714
       failTaskOnFailedTests: true
 
-  - task: PublishBuildArtifacts@1
-    condition: always()
-    retryCountOnTaskFailure: 10
-    inputs:
-      PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: ${{ parameters.TEST_KIND }}-tests-tvos-${{ parameters.UITEST_VARIANT }}-results
-      ArtifactType: Container
+  # The staging directory only ever receives the NUnit UI-test harness's screenshots, and the runtime
+  # kind does not run that harness: tvos-uitest-run.sh launches the app and polls for its own results
+  # file. Publishing it on a runtime job just reports an empty directory on the build summary.
+  - ${{ if ne(parameters.TEST_KIND, 'runtime') }}:
+    - task: PublishBuildArtifacts@1
+      condition: always()
+      retryCountOnTaskFailure: 10
+      inputs:
+        PathtoPublish: $(build.artifactstagingdirectory)
+        ArtifactName: ${{ parameters.TEST_KIND }}-tests-tvos-${{ parameters.UITEST_VARIANT }}-results
+        ArtifactType: Container
 
   # logs files are large, so we create them outside of `artifactstagingdirectory` and publish
   # them in a separate artifacts container.

--- a/build/nuget/Uno.Foundation.nuspec
+++ b/build/nuget/Uno.Foundation.nuspec
@@ -13,8 +13,20 @@
 		<description>Build Mobile, Desktop and WebAssembly apps with C# and XAML. Today. Open source and professionally supported.</description>
 		<copyright>Copyright (C) 2015-2025 Uno Platform Inc. - all rights reserved</copyright>
 		<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
+
+		<!-- The package has no dependencies, but every lib folder still needs a group so consumers resolve an exact match. -->
+		<dependencies>
+			<group targetFramework="net10.0" />
+			<group targetFramework="net10.0-android30.0" />
+			<group targetFramework="net10.0-ios26.0" />
+			<group targetFramework="net10.0-tvos26.0" />
+			<group targetFramework="net11.0" />
+			<group targetFramework="net11.0-android36.0" />
+			<group targetFramework="net11.0-ios26.5" />
+			<group targetFramework="net11.0-tvos26.5" />
+		</dependencies>
 	</metadata>
-	
+
 	<files>
 		<!-- Icon File -->
 		<file src="..\..\src\Common\uno.png" target="/" />

--- a/build/nuget/Uno.WinRT.nuspec
+++ b/build/nuget/Uno.WinRT.nuspec
@@ -14,8 +14,32 @@
 		<copyright>Copyright (C) 2015-2025 Uno Platform Inc. - all rights reserved</copyright>
 		<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
 
+		<!-- One group per lib folder, so consumers resolve an exact match instead of the nearest compatible one. -->
 		<dependencies>
-			<dependency id="Uno.Foundation" version="1.0.0" />
+			<group targetFramework="net10.0">
+				<dependency id="Uno.Foundation" version="1.0.0" />
+			</group>
+			<group targetFramework="net10.0-android30.0">
+				<dependency id="Uno.Foundation" version="1.0.0" />
+			</group>
+			<group targetFramework="net10.0-ios26.0">
+				<dependency id="Uno.Foundation" version="1.0.0" />
+			</group>
+			<group targetFramework="net10.0-tvos26.0">
+				<dependency id="Uno.Foundation" version="1.0.0" />
+			</group>
+			<group targetFramework="net11.0">
+				<dependency id="Uno.Foundation" version="1.0.0" />
+			</group>
+			<group targetFramework="net11.0-android36.0">
+				<dependency id="Uno.Foundation" version="1.0.0" />
+			</group>
+			<group targetFramework="net11.0-ios26.5">
+				<dependency id="Uno.Foundation" version="1.0.0" />
+			</group>
+			<group targetFramework="net11.0-tvos26.5">
+				<dependency id="Uno.Foundation" version="1.0.0" />
+			</group>
 		</dependencies>
 	</metadata>
 	<files>

--- a/build/nuget/Uno.WinUI.Graphics2DSK.nuspec
+++ b/build/nuget/Uno.WinUI.Graphics2DSK.nuspec
@@ -10,39 +10,19 @@
 		<description>This package provides 2D graphics extensions for an Uno Platform application.</description>
 		<copyright>Uno Platform</copyright>
 		<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
+		<!-- One group per lib folder: the netX.0 assembly also serves the mobile heads, which resolve the netX.0 group. -->
 		<dependencies>
 			<group targetFramework="net10.0">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="SkiaSharp" version="4.151.1" />
+			</group>
+			<group targetFramework="net11.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="SkiaSharp" version="4.151.1" />
 			</group>
 
 			<group targetFramework="net10.0-windows10.0.19041.0">
 				<dependency id="Microsoft.WindowsAppSDK" version="2.4.0" />
-				<dependency id="SkiaSharp" version="4.151.1" />
-			</group>
-
-			<group targetFramework="net10.0-android36.0">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.151.1" />
-			</group>
-			<group targetFramework="net11.0-android37.0">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.151.1" />
-			</group>
-			<group targetFramework="net10.0-ios26.0">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.151.1" />
-			</group>
-			<group targetFramework="net11.0-ios26.5">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.151.1" />
-			</group>
-			<group targetFramework="net10.0-tvos26.0">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.151.1" />
-			</group>
-			<group targetFramework="net11.0-tvos26.5">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="SkiaSharp" version="4.151.1" />
 			</group>
 		</dependencies>

--- a/build/nuget/Uno.WinUI.MSAL.nuspec
+++ b/build/nuget/Uno.WinUI.MSAL.nuspec
@@ -10,6 +10,7 @@
 		<description>This package provides the extensions to MSAL (Microsoft.Identity.Client) for an Uno Platform application.</description>
 		<copyright>Uno Platform</copyright>
 		<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
+		<!-- One group per lib folder, so consumers resolve an exact match instead of the nearest compatible one. -->
 		<dependencies>
 			<group targetFramework="net10.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
@@ -26,7 +27,15 @@
 			</group>
 			END UWP-specific -->
 
-			<group targetFramework="net10.0-android36.0">
+			<!-- BEGIN WinUI-specific -->
+			<!-- The Windows flavour builds against WinAppSDK rather than Uno.WinUI. -->
+			<group targetFramework="net10.0-windows10.0.19041.0">
+				<dependency id="Microsoft.WindowsAppSDK" version="2.4.0" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
+			</group>
+			<!-- END WinUI-specific -->
+
+			<group targetFramework="net10.0-android">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
@@ -38,7 +47,7 @@
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
-			<group targetFramework="net11.0-android37.0">
+			<group targetFramework="net11.0-android">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>

--- a/build/nuget/Uno.WinUI.XamlHost.nuspec
+++ b/build/nuget/Uno.WinUI.XamlHost.nuspec
@@ -10,25 +10,12 @@
 		<description>This package provides the XAML hosting capabilities for an Uno Platform application.</description>
 		<copyright>Uno Platform</copyright>
 		<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
+		<!-- The package only ships netX.0 assemblies; the mobile heads resolve those same groups. -->
 		<dependencies>
-			<group targetFramework="UAP10.0.19041">
-			</group>
-			<group targetFramework="net10.0-android30.0">
+			<group targetFramework="net10.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
-			<group targetFramework="net10.0-ios26.0">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-			</group>
-			<group targetFramework="net10.0-tvos26.0">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-			</group>
-			<group targetFramework="net11.0-android37.0">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-			</group>
-			<group targetFramework="net11.0-ios26.5">
-				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-			</group>
-			<group targetFramework="net11.0-tvos26.0">
+			<group targetFramework="net11.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
 		</dependencies>

--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -509,6 +509,13 @@
 		<AppxAutoIncrementPackageRevision>false</AppxAutoIncrementPackageRevision>
 		<GenerateAppxPackageOnBuild>false</GenerateAppxPackageOnBuild>
 		<ApplicationManifest>Platforms\Windows\app.manifest</ApplicationManifest>
+		<!--
+		Roslyn, MSTest and System.CommandLine ship localized satellite assemblies with no neutral
+		variant, which MakePri reports as PRI263. Nothing here reads their translated messages, so
+		keep only the neutral ones. The app's own localization tests use .resw, which goes into PRI
+		and is unaffected.
+		-->
+		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(_Platform)' == 'windows'">
 		<AppxManifest Include="Package.appxmanifest">
@@ -700,8 +707,34 @@
 		<Content Update="@(Content)" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
 
+	<!--
+	The shared project carries lowercase copies of the MSIX tile assets that Platforms\Windows\Assets
+	also provides. Both link to Assets\<name>, and the packaging tooling reports the collision as
+	APPX1102 before dropping the shared copy anyway — drop it here instead. Must stay below the shared
+	import that adds them.
+	-->
+	<ItemGroup Condition="'$(_Platform)' == 'windows'">
+		<Content Remove="..\SamplesApp.Shared\Assets\lockscreenlogo.scale-200.png" />
+		<Content Remove="..\SamplesApp.Shared\Assets\splashscreen.scale-200.png" />
+		<Content Remove="..\SamplesApp.Shared\Assets\square150x150logo.scale-200.png" />
+		<Content Remove="..\SamplesApp.Shared\Assets\square44x44logo.scale-200.png" />
+		<Content Remove="..\SamplesApp.Shared\Assets\StoreLogo.png" />
+		<Content Remove="..\SamplesApp.Shared\Assets\wide310x150logo.scale-200.png" />
+	</ItemGroup>
+
 	<!-- Must stay the last import: replaces the implicit bottom import an Sdk attribute would have added. -->
 	<Import Project="$(MSBuildThisFileDirectory)..\..\Uno.Sdk\Sdk\Sdk.targets" />
+
+	<!--
+	Uno.Sdk points every WinAppSDK head at Properties\PublishProfiles\win-$(Platform).pubxml. Apps from
+	the templates ship one; this head does not, and must not — the template profile turns on trimming,
+	ReadyToRun and self-contained, none of which a reflection-driven test host survives. CI passes
+	RuntimeIdentifier and Platform on the command line instead, so clear the default and its NETSDK1198.
+	Has to sit below the import that sets it.
+	-->
+	<PropertyGroup Condition="'$(_Platform)' == 'windows'">
+		<PublishProfile />
+	</PropertyGroup>
 
 	<!--
 	Uno.Resizetizer decides "is this a Skia app" from $(UnoRuntimeIdentifier) alone, which this head sets

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Order.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Order.xaml
@@ -9,19 +9,19 @@
 				x:FieldModifier="public" Background="Orange" Width="200" Height="200">
 		<Border x:Name="tb01"
 				x:FieldModifier="public"
-				x:Load="{x:Bind IsLoaded1, Mode=OneWay}" 
+				x:Load="{x:Bind IsLoaded1, Mode=OneTime}" 
 				Width="50" 
 				Height="50"
 				Background="Red" />
 		<Border x:Name="tb02"
 				x:FieldModifier="public"
-				x:Load="{x:Bind IsLoaded2, Mode=OneWay}"
+				x:Load="{x:Bind IsLoaded2, Mode=OneTime}"
 				Width="150"
 				Height="50"
 				Background="Green" />
 		<Border x:Name="tb03"
 				x:FieldModifier="public"
-				x:Load="{x:Bind IsLoaded3, Mode=OneWay}"
+				x:Load="{x:Bind IsLoaded3, Mode=OneTime}"
 				Width="50"
 				Height="150"
 				Background="Blue" />


### PR DESCRIPTION
**GitHub Issue:** #6670

<!-- Deliberately not `closes`: #6670 is the umbrella issue for CI warning cleanup. This is the
     second batch, picking up the tail #24445 listed under "Left for follow-up". -->

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Second batch of CI warning cleanup, taking the tail that #24445 deferred.

Measured against build 232888 — the run on #24445 — which reports **43 warnings** on its Azure
DevOps summary. This PR removes **31** of them, leaving 12.

### A note on the baseline: the summary undercounts

Azure DevOps records at most **10 issues per task** on the timeline, and the summary is built from
those records. Two tasks in build 232888 sit exactly at 10, and both were hiding more:

| Task | On the summary | Actually in the log |
|---|---:|---:|
| `BuildMSIX` | 10 | 14 |
| `Build Wasm Skia Head` | 10 | 13 |

So the real count for that build is 50, not 43, and this PR removes 35 of them. Any warning
baseline taken from timeline records alone — including the 338 in #24445 — is a floor, not a total.

### 9 — `NU5128` / `NU5129` in the nuspec-driven packs

`NU5128` fired on five nuspecs whose `<dependencies>` groups did not describe the same target
frameworks as their `lib/` folders:

- `Uno.Foundation` and `Uno.WinRT` declared no per-framework groups at all, so every one of their
  eight `lib/` folders resolved through a fallback group.
- `Uno.WinUI.Graphics2DSK` was missing a `net11.0` group and carried six mobile groups with no
  `lib/` folder behind them.
- `Uno.WinUI.MSAL` pinned android platform versions (`net10.0-android36.0`) its `lib/` folders do
  not use (`net10.0-android`), and had no group for its WinAppSDK `lib/`.
- `Uno.WinUI.XamlHost` declared UAP and mobile groups but only ships `netX.0` assemblies — so a
  plain desktop head got **no** `Uno.WinUI` dependency at all.

Every framework that can resolve these packages ends up with the same dependency set as before; it
now comes from an exact group match rather than a fallback. One exception, called out below.

Two packages genuinely cannot satisfy `NU5128`, and `Uno.WinUI` cannot satisfy `NU5129`:

- **Lottie and Svg** ship one `netX.0` assembly for every head, but the mobile heads need extra
  `SkiaSharp.NativeAssets.*` dependencies, so those groups have no `lib/` folder of their own. The
  alternative — `lib/<tfm>/_._` placeholders — would resolve to *no assembly* on mobile and break
  the packages outright.
- **Uno.WinUI**'s `buildTransitive` root holds helper targets that the per-TFM entry points import
  by relative path, so there is deliberately no `buildTransitive/Uno.WinUI.targets` to pair them.

The pack step shared a single `NoWarn` across all nine nuspecs, so waiving a code for one layout
would have silenced it everywhere. It is now driven from an item group carrying per-package
`NoWarn`, and only those three waivers are applied.

That change also fixes a latent bug in the shared list:
`NoWarn=NU5100,NU5105,NU5131;NU5123` — the `;` ends the `-Properties` value, so `NU5123` was never
actually suppressed despite the comment saying it was.

### 14 — the `SamplesApp` MSIX pack (`APPX1102`, `PRI263`, `NETSDK1198`)

Three unrelated causes on the WinAppSDK head:

- **`APPX1102` (6)** — the shared project and `Platforms\Windows\Assets` both link the six MSIX tile
  assets to `Assets\<name>`, differing only in case. The head's copy already wins; the packaging
  tooling was reporting the collision and then discarding the shared one. Dropped from `Content` on
  Windows instead.
- **`PRI263` (4)** — invisible on the summary (see the cap above). Roslyn, MSTest and
  System.CommandLine ship localized satellite assemblies with no neutral variant for MakePri to fall
  back to. Nothing here reads their translated messages, so only the neutral ones are kept. The app's
  own localization tests use `.resw`, which goes into PRI and is untouched.
- **`NETSDK1198` (1)** — Uno.Sdk points every WinAppSDK head at
  `Properties\PublishProfiles\win-$(Platform).pubxml`. Apps from the templates ship one; this head
  does not and must not — the template profile turns on trimming, ReadyToRun and self-contained,
  none of which a reflection-driven test host survives. CI passes `RuntimeIdentifier` and `Platform`
  on the command line, so the default is cleared.

### 12 — empty iOS/tvOS runtime-test publishes

#24445 flagged these as *"may be masking a real staging gap and is worth investigating rather than
silencing"*. Investigated: there is no staging gap.

In `RuntimeTests` mode the Apple scripts do not use the NUnit UI-test harness at all — they
`simctl launch` the app and poll for the results file it writes itself, which the script copies to
`TestResult-original.xml` (published by the task above, which works). `RuntimeTestResults*.xml` and
the screenshots under the staging directory are both written by `SamplesApp.UITests`, so on a
runtime job they are always absent, and publishing them reports "no test result files were found"
(4x) and "directory is empty" (8x) every run.

Both are now gated on `TEST_KIND` rather than removed, so a future `ui` or `screenshot` job still
publishes them.

### 3 — `WMC1506` in `When_xLoad_Order` ⚠️ reverses a decision from #24445

#24445 said: *"`When_xLoad_Order` is deliberately untouched: it drives `x:Load` through an explicit
`Bindings.Update()` call, which is the behaviour under test."*

This PR changes it to `Mode=OneTime` anyway, because the `Bindings.Update()` call is what makes
`OneTime` correct rather than what makes `OneWay` necessary — `Update()` re-applies every binding
regardless of mode, and the test still drives every update through it. The three sources are plain
auto-properties on the control with no notification path, which is exactly what `WMC1506` reports.

Verified rather than assumed:

- `XamlFileGenerator.BuildXBindApply` emits `ApplyXBind()` for **every** `x:Bind` component in
  `Bindings.Update()`, with no filter on mode.
- `Given_xLoad` runs 11/11 green on Skia desktop with the change. The test is its own control: if
  `Update()` did not re-apply a `OneTime` binding, the assertion right after
  `IsLoaded2 = true; Refresh()` would still see an `ElementStub`.

The WinUI XAML compiler side is what CI validates. **Happy to drop this commit** (`test(xload)`) if
you would still rather leave it — it is self-contained and nothing else depends on it.

## Behaviour changes to be aware of

Two things here are not pure no-ops:

1. **`Uno.WinUI.MSAL` on a WinAppSDK head.** The new `net10.0-windows10.0.19041.0` dependency group
   carries `Microsoft.WindowsAppSDK` instead of `Uno.WinUI`, mirroring what
   `Uno.WinUI.Graphics2DSK` already declares for the same framework. A `net10.0-windows` head
   previously picked up a transitive `Uno.WinUI` through the `net10.0` fallback and no longer does.
   The Windows flavour builds against WinAppSDK, so this looks right, but it is a change to a
   shipped package.
2. **`SatelliteResourceLanguages=en`** drops the non-English satellite assemblies of four packages
   from the Windows MSIX. Smaller package, no localized Roslyn/MSTest messages.

## Found along the way, not fixed here

`Uno.WinUI.MSAL` and `Uno.WinUI.Graphics2DSK` pack only `lib/net10.0-windows10.0.19041.0`, while
both projects build the current WinAppSDK TFM as well. NuGet's reducer prefers the higher framework
version over the matching platform, so on a `net11.0-windows10.0.19041.0` head both packages resolve
`lib/net11.0` — the Skia build — instead of the WinAppSDK one. `Uno.WinUI` already works around this
with the block its nuspec comments as *"Duplicated block to avoid nuget from downgrading to
net11.0"*; the two add-ins never got the same treatment.

Measured with a synthetic package and a positive control (adding the `net11.0-windows` folder flips
the selection back). Not reproducible in-repo — `SamplesApp` consumes both add-ins by
`ProjectReference` — so it is a packaging defect, out of scope for a warning cleanup, and tracked
separately.

## What is left

Still standing after this PR, on the summary: 12.

- `UNOBLD006` (2) — Uno's own deliberate simulator-boot diagnostic. Signal, not noise.
- "Free memory is lower than 5%" (10 shown, 13 real) — the ADO agent's resource monitor firing while
  `wasm-opt -O2` peaks during the WASM native link. A machine condition, not something the repo
  controls without slowing the build.

Untouched from #24445's follow-up list because they still need a decision or real work:
`XA4211`/`XA1006` (preview Android API level), `MT7156`, `APT2000`, macOS pool disk space.

## Validation

No behavioural change is intended outside the two items called out above, so each change was checked
against the tree it came from rather than only compiled.

**Packaging** — a shadow tree mirroring the pack inputs (real nuspecs, real `buildTransitive`
sources, stubbed build outputs) reproduces all 9 warnings from build 232888 **byte for byte**,
including the exact bullet list under each. After the change all nine packages pack silent, using
the same `NoWarn` composition the target now builds. The MSBuild batching and quoting were proven
separately by echoing the generated command lines, and `XmlPoke` still reaches all 8 nested
`Uno.Foundation` dependencies now that they live inside groups.

**`APPX1102`** — MSBuild `-getItem:Content` diffed before and after on
`net11.0-windows10.0.19041.0`: 351 → 345 items, and the six removed are exactly the shared tile
assets, nothing else. The desktop head is unchanged at 352 and keeps all six.

**`NETSDK1198` / `PRI263`** — `-getProperty` confirms `PublishProfile` is empty and
`SatelliteResourceLanguages` is `en` on the Windows head, and that the desktop head sees neither.

**`WMC1506`** — `Given_xLoad`, 11/11 passed on Skia desktop (`net11.0-desktop`, Release). The
generator path was read to confirm `Bindings.Update()` does not filter by binding mode.

**Builds** — `SamplesApp` `net11.0-desktop` builds with 0 warnings, 0 errors.

The two pipeline templates are the one thing that cannot be exercised locally. Both YAML files
parse, `TEST_KIND` is a declared parameter in each, and the gated tasks are unchanged apart from
indentation. They need a CI run to confirm.

## Relationship to #24445

Independent, not stacked — this branch is cut from `master` and the five commits cherry-pick onto it
cleanly. Both PRs touch `SamplesApp.csproj` in different regions; a test merge of the two branches
auto-merges with no conflicts and keeps both sides' hunks, so they can land in either order.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, no feature change; `Given_xLoad` was run as the regression check for the one test edit
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no user-facing surface changes
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpHaabjU7jWrNpp1QcXBbL
