### PR TITLE
docs: add Claude Code cloud environment setup

### DIFF
--- a/doc/articles/common-issues-ai-agents.md
+++ b/doc/articles/common-issues-ai-agents.md
@@ -42,6 +42,19 @@ The Uno Platform App MCP may fail to start in Claude/Codex/Copilot CLI when it i
 
 To fix this issue, change directories to a folder that contains the `.sln` or `.slnx` file of your project — or, for solution-less projects, the folder containing the `global.json` file that declares your `Uno.Sdk` version.
 
+## A cloud environment setup script fails with exit code 100
+
+A [setup script](https://code.claude.com/docs/en/cloud-environments#setup-scripts) that installs the .NET SDK can fail before it reaches the install:
+
+```text
+E: Failed to fetch https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu/dists/noble/InRelease  403  Forbidden
+E: The repository 'https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble InRelease' is no longer signed.
+```
+
+The base image carries third-party PPAs served from `ppa.launchpadcontent.net`, which is not on the default network allowlist. `apt-get update` exits 100 when any repository fails to refresh, and a setup script that exits non-zero stops the session from starting, so the failure happens before the .NET SDK install runs.
+
+Disable those repository files before updating, and make the update non-fatal. See [Using Claude Code in a cloud environment](xref:Uno.GetStarted.AI.Claude) for the full script.
+
 ## Diagnosing Dev Server issues
 
 > [!TIP]

--- a/doc/articles/get-started-ai-claude.md
+++ b/doc/articles/get-started-ai-claude.md
@@ -68,7 +68,7 @@ For the full skill catalog, update instructions, and other installation options,
     grep -rlE 'launchpadcontent\.net|ppa\.launchpad' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r -I{} mv {} {}.disabled
 
     apt-get update -qq || true
-    apt-get install -y -qq dotnet-sdk-10.0
+    apt-get install -y dotnet-sdk-10.0
     dotnet --version
     ```
 

--- a/doc/articles/get-started-ai-claude.md
+++ b/doc/articles/get-started-ai-claude.md
@@ -48,9 +48,15 @@ For the full skill catalog, update instructions, and other installation options,
 
 ## Using Claude Code in a cloud environment
 
-[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web) runs each session on a fresh Ubuntu 24.04 virtual machine. The .NET SDK is not pre-installed there, so the `uno-app` MCP fails to start with `ENOENT: Executable not found in $PATH: dotnet`. Install the SDK with a [setup script](https://code.claude.com/docs/en/cloud-environments#setup-scripts), which runs once before Claude Code launches.
+[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web) runs each session on a fresh Ubuntu 24.04 virtual machine. The .NET SDK is not pre-installed there, so the `uno-app` MCP fails to start with `ENOENT: Executable not found in $PATH: dotnet`. Install the SDK with a [setup script](https://code.claude.com/docs/en/cloud-environments#setup-scripts) on the cloud environment, which runs once before Claude Code launches.
 
-1. Open [claude.ai/code](https://claude.ai/code), then open the environment selector and edit the environment your sessions use.
+1. Open [claude.ai/code](https://claude.ai/code).
+
+1. In the row above the message box, select the cloud icon showing the current environment's name, for example **Default**. This opens the environment selector. There is no settings page or direct URL for it.
+
+1. Under **Cloud**, hover over the environment your sessions use, then select the settings icon that appears on its right. To set up a separate environment for Uno Platform work instead, select **Add cloud environment**.
+
+1. The environment dialog opens with fields for **Name**, **Network access**, **Environment variables**, and **Setup script**. Leave **Network access** on **Trusted**, which reaches the Ubuntu package feed that provides the SDK.
 
 1. In the **Setup script** field, enter:
 
@@ -66,23 +72,34 @@ For the full skill catalog, update instructions, and other installation options,
     dotnet --version
     ```
 
-1. If any project in your repository targets `net9.0`, add the following to the **Environment variables** field. Only the .NET 10 runtime is available from the Ubuntu 24.04 feed, so `net9.0` assemblies need to roll forward:
+1. If any project in your repository targets `net9.0`, add the following line to the **Environment variables** field, which takes `.env` format. Only the .NET 10 runtime is available from the Ubuntu 24.04 feed, so `net9.0` assemblies need to roll forward:
 
     ```text
     DOTNET_ROLL_FORWARD=LatestMajor
     ```
 
-1. Save the environment, then start a **new** session. Sessions that are already running keep the configuration they started with.
+1. Select **Create environment**, or **Save** when you are editing an existing environment.
 
-1. In the session, run `dotnet --version` to confirm the SDK is present, then run `/mcp` to confirm the Uno Platform MCPs are connected.
+1. Start a **new** session. Sessions that are already running keep the configuration they started with, so an existing session will not pick up the change.
 
-The script writes to disk what later sessions need. Setup scripts must exit zero or the session fails to start, which is why `apt-get update` ends in `|| true` and the script ends in `dotnet --version` so a failed install surfaces immediately. After the script completes, the filesystem is snapshotted and reused, so later sessions start with the SDK already installed and skip the script.
+1. The first session in the environment runs the setup script before Claude Code launches, which adds roughly 35 seconds. When it finishes, confirm the install:
+
+    ```bash
+    dotnet --version
+    ```
+
+    This should report a `10.x` version.
+
+1. Run `/mcp` to confirm the Uno Platform MCPs are connected. The `uno-app` entry should now start instead of reporting `ENOENT`.
+
+> [!IMPORTANT]
+> A setup script must exit zero or the session fails to start. That is why `apt-get update` ends in `|| true`, and why the script ends in `dotnet --version` so that a failed install surfaces as a failed session start rather than as a missing binary later. If your session does not start, see [A cloud environment setup script fails with exit code 100](xref:Uno.UI.CommonIssues.AIAgents).
 
 > [!NOTE]
-> .NET 10 is published in the Ubuntu 24.04 package feed, which the default **Trusted** network access level reaches through `archive.ubuntu.com`. .NET 9 is published only in the `ppa:dotnet/backports` repository, which is not on the default allowlist. Target `net10.0`, or set `DOTNET_ROLL_FORWARD` as shown above.
+> The setup script runs on the first session in the environment. Anthropic then snapshots the filesystem and reuses it, so later sessions start with the SDK already installed and skip the script. The script runs again when you change it, when you change the environment's allowed network hosts, and when the snapshot expires after roughly seven days.
 
 > [!TIP]
-> Installing a workload, for example `dotnet workload install android`, adds several minutes to the script. Setup scripts should finish within roughly five minutes, so add workloads on their own line ending in `|| true` and confirm the base install works first.
+> .NET 10 is published in the Ubuntu 24.04 package feed, which the **Trusted** network access level reaches through `archive.ubuntu.com`. .NET 9 is published only in the `ppa:dotnet/backports` repository, which is not on the default allowlist, so target `net10.0` or set `DOTNET_ROLL_FORWARD` as shown above. Installing a workload, for example `dotnet workload install android`, adds several minutes to a script that should finish within roughly five minutes, so add workloads on their own line ending in `|| true` and confirm the base install works first.
 
 ## Next Steps
 

--- a/doc/articles/get-started-ai-claude.md
+++ b/doc/articles/get-started-ai-claude.md
@@ -46,6 +46,44 @@ Uno Platform ships a catalog of agent skills — covering areas such as MVUX, na
 
 For the full skill catalog, update instructions, and other installation options, see [Skills & Plugins](xref:Uno.PlatformStudio.Skills).
 
+## Using Claude Code in a cloud environment
+
+[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web) runs each session on a fresh Ubuntu 24.04 virtual machine. The .NET SDK is not pre-installed there, so the `uno-app` MCP fails to start with `ENOENT: Executable not found in $PATH: dotnet`. Install the SDK with a [setup script](https://code.claude.com/docs/en/cloud-environments#setup-scripts), which runs once before Claude Code launches.
+
+1. Open [claude.ai/code](https://claude.ai/code), then open the environment selector and edit the environment your sessions use.
+
+1. In the **Setup script** field, enter:
+
+    ```bash
+    #!/bin/bash
+    export DEBIAN_FRONTEND=noninteractive DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+    # Disable third-party PPAs that are not on the default network allowlist
+    grep -rlE 'launchpadcontent\.net|ppa\.launchpad' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r -I{} mv {} {}.disabled
+
+    apt-get update -qq || true
+    apt-get install -y -qq dotnet-sdk-10.0
+    dotnet --version
+    ```
+
+1. If any project in your repository targets `net9.0`, add the following to the **Environment variables** field. Only the .NET 10 runtime is available from the Ubuntu 24.04 feed, so `net9.0` assemblies need to roll forward:
+
+    ```text
+    DOTNET_ROLL_FORWARD=LatestMajor
+    ```
+
+1. Save the environment, then start a **new** session. Sessions that are already running keep the configuration they started with.
+
+1. In the session, run `dotnet --version` to confirm the SDK is present, then run `/mcp` to confirm the Uno Platform MCPs are connected.
+
+The script writes to disk what later sessions need. Setup scripts must exit zero or the session fails to start, which is why `apt-get update` ends in `|| true` and the script ends in `dotnet --version` so a failed install surfaces immediately. After the script completes, the filesystem is snapshotted and reused, so later sessions start with the SDK already installed and skip the script.
+
+> [!NOTE]
+> .NET 10 is published in the Ubuntu 24.04 package feed, which the default **Trusted** network access level reaches through `archive.ubuntu.com`. .NET 9 is published only in the `ppa:dotnet/backports` repository, which is not on the default allowlist. Target `net10.0`, or set `DOTNET_ROLL_FORWARD` as shown above.
+
+> [!TIP]
+> Installing a workload, for example `dotnet workload install android`, adds several minutes to the script. Setup scripts should finish within roughly five minutes, so add workloads on their own line ending in `|| true` and confirm the base install works first.
+
 ## Next Steps
 
 Now that you are set up, let's [create your first app](xref:Uno.GettingStarted.CreateAnApp.AI.Claude).

--- a/doc/articles/includes/use-uno-check-inline-linux-noheader.md
+++ b/doc/articles/includes/use-uno-check-inline-linux-noheader.md
@@ -2,7 +2,7 @@
 1. If `dotnet --version` returns `command not found`:
     - Follow the [official directions](https://learn.microsoft.com/dotnet/core/install/linux?WT.mc_id=dotnet-35129-website#packages) for installing .NET.
       > [!IMPORTANT]
-      > On Ubuntu 24.04 and later, install .NET from the Ubuntu package feed. The Microsoft package repository no longer publishes .NET packages for Ubuntu. On Ubuntu 22.04, .NET is available from both feeds and you should use only one of them. Refer to the directions from Microsoft on [installing .NET on Ubuntu](https://learn.microsoft.com/dotnet/core/install/linux-ubuntu-install) and make sure to select your Ubuntu version.
+      > On Ubuntu 24.04 and later, install .NET from the Ubuntu package feed. The Microsoft package repository no longer publishes .NET packages for Ubuntu. On Ubuntu 22.04, .NET is available from both feeds and you should use only one of them. On Ubuntu earlier than 22.04, use the Microsoft package repository. Refer to the directions from Microsoft on [installing .NET on Ubuntu](https://learn.microsoft.com/dotnet/core/install/linux-ubuntu-install) and make sure to select your Ubuntu version.
 1. Then, setup uno.check by installing or updating the tool with:
 
     ```bash

--- a/doc/articles/includes/use-uno-check-inline-linux-noheader.md
+++ b/doc/articles/includes/use-uno-check-inline-linux-noheader.md
@@ -2,7 +2,7 @@
 1. If `dotnet --version` returns `command not found`:
     - Follow the [official directions](https://learn.microsoft.com/dotnet/core/install/linux?WT.mc_id=dotnet-35129-website#packages) for installing .NET.
       > [!IMPORTANT]
-      > If you are using Ubuntu 24.04 or earlier, use the Microsoft feed to install .NET. On later versions, you may install .NET directly from Ubuntu's official feed. In any case, you may refer to the directions from Microsoft on [installing .NET on Ubuntu](https://learn.microsoft.com/dotnet/core/install/linux-ubuntu#register-the-microsoft-package-repository) and make sure to select your Ubuntu version.
+      > On Ubuntu 24.04 and later, install .NET from the Ubuntu package feed. The Microsoft package repository no longer publishes .NET packages for Ubuntu. On Ubuntu 22.04, .NET is available from both feeds and you should use only one of them. Refer to the directions from Microsoft on [installing .NET on Ubuntu](https://learn.microsoft.com/dotnet/core/install/linux-ubuntu-install) and make sure to select your Ubuntu version.
 1. Then, setup uno.check by installing or updating the tool with:
 
     ```bash


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Documentation-only change. -->

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Claude Code cloud sessions run on a fresh Ubuntu 24.04 VM with common toolchains pre-installed, but the .NET SDK is not one of them ([Claude Code docs](https://code.claude.com/docs/en/cloud-environments#installed-tools)). The `uno-app` MCP therefore fails to start with `ENOENT: Executable not found in $PATH: dotnet`, and nothing in our getting-started docs covers it.

Three changes:

**1. `get-started-ai-claude.md` — new "Using Claude Code in a cloud environment" section.**

Documents the setup script that installs the .NET SDK, the `DOTNET_ROLL_FORWARD` variable needed when a project targets `net9.0`, and the verification steps. Also notes the two constraints that shape the script: setup scripts must exit zero or the session fails to start, and the filesystem is snapshotted afterward so later sessions skip the script.

**2. `common-issues-ai-agents.md` — new troubleshooting entry for setup scripts failing with exit code 100.**

The base image ships third-party PPAs served from `ppa.launchpadcontent.net`, which is not on the default network allowlist (`ppa.launchpad.net` and `archive.ubuntu.com` are). `apt-get update` exits 100 when any repository fails to refresh, which aborts session start before the .NET install runs. This fails in a confusing way, because the error names Python and PHP repositories in what looks like a .NET problem.

**3. `includes/use-uno-check-inline-linux-noheader.md` — corrected Ubuntu feed guidance.**

The include currently says "If you are using Ubuntu 24.04 or earlier, use the Microsoft feed to install .NET." Microsoft's current guidance is the opposite: for Ubuntu 24.04 and later, ".NET is available in the Ubuntu package manager feeds. The Microsoft package repository no longer contains .NET packages for Ubuntu" ([Install .NET on Ubuntu](https://learn.microsoft.com/dotnet/core/install/linux-ubuntu-install)). The Microsoft feed column reads **None** for 24.04, 25.04, 25.10, and 26.04. Following the current text leads to a missing package rather than an install.

This third change is separable from the first two if you would rather it went in its own PR. It is included here because the new cloud section installs from the Ubuntu feed, which the include currently contradicts. Note it is a shared include, so it also affects the Codex, GitHub Copilot CLI, Cursor, and Antigravity getting-started pages.

### Verification

The setup script in this PR was run in a Claude Code cloud session. `dotnet --version` returns `10.0.112`, and the Uno Platform MCPs connect afterward. The exit-code-100 failure and its error output were reproduced first, which is where the PPA workaround comes from.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, documentation only
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, documentation only
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
