### PR TITLE
test: Disable five flaky runtime tests (InputPane occlusion, scroll chaining, BitmapIcon monochrome)

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
@@ -81,6 +81,7 @@ public class Given_InputPane
 	[RunsOnUIThread]
 	[RequiresFullWindow]
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	[Ignore("Flaky on all targets - https://github.com/unoplatform/uno/issues/24489")]
 	public async Task When_Focused_TextBox_Has_Content_Below_Then_Scrolled_Above_Occlusion()
 	{
 		var textBox = new TextBox { Height = 40, PlaceholderText = "middle" };
@@ -202,6 +203,7 @@ public class Given_InputPane
 	[RunsOnUIThread]
 	[RequiresFullWindow]
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	[Ignore("Flaky on all targets - https://github.com/unoplatform/uno/issues/24489")]
 	public async Task When_Focused_Element_Not_Occluded_Then_Centered_Content_Is_Not_Moved()
 	{
 		var (scrollViewer, card, textBox) = BuildCenteredCardPage();
@@ -305,6 +307,7 @@ public class Given_InputPane
 	[RunsOnUIThread]
 	[RequiresFullWindow]
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	[Ignore("Flaky on all targets - https://github.com/unoplatform/uno/issues/24489")]
 	public async Task When_Occluded_Field_In_Viewport_Sized_Content_Then_Scrolled_Above_Occlusion()
 	{
 		var textBox = new TextBox { Height = 40, PlaceholderText = "bottom", VerticalAlignment = VerticalAlignment.Bottom };

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
@@ -81,7 +81,7 @@ public class Given_InputPane
 	[RunsOnUIThread]
 	[RequiresFullWindow]
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
-	[Ignore("Flaky on all targets - https://github.com/unoplatform/uno/issues/24489")]
+	[Ignore("Flaky on all targets, not one platform - https://github.com/unoplatform/uno/issues/24489")]
 	public async Task When_Focused_TextBox_Has_Content_Below_Then_Scrolled_Above_Occlusion()
 	{
 		var textBox = new TextBox { Height = 40, PlaceholderText = "middle" };
@@ -203,7 +203,7 @@ public class Given_InputPane
 	[RunsOnUIThread]
 	[RequiresFullWindow]
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
-	[Ignore("Flaky on all targets - https://github.com/unoplatform/uno/issues/24489")]
+	[Ignore("Flaky on all targets, not one platform - https://github.com/unoplatform/uno/issues/24489")]
 	public async Task When_Focused_Element_Not_Occluded_Then_Centered_Content_Is_Not_Moved()
 	{
 		var (scrollViewer, card, textBox) = BuildCenteredCardPage();
@@ -307,7 +307,7 @@ public class Given_InputPane
 	[RunsOnUIThread]
 	[RequiresFullWindow]
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
-	[Ignore("Flaky on all targets - https://github.com/unoplatform/uno/issues/24489")]
+	[Ignore("Flaky on all targets, not one platform - https://github.com/unoplatform/uno/issues/24489")]
 	public async Task When_Occluded_Field_In_Viewport_Sized_Content_Then_Scrolled_Above_Occlusion()
 	{
 		var textBox = new TextBox { Height = 40, PlaceholderText = "bottom", VerticalAlignment = VerticalAlignment.Bottom };

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_BitmapIcon.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_BitmapIcon.cs
@@ -107,7 +107,7 @@ public class Given_BitmapIcon
 #elif !__SKIA__
 	[Ignore("BitmapIcon flicker fix is Skia-specific - Image.skia.cs updates the surface brush color filter in place without reloading.")]
 #endif
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaUIKit)] // Flaky - https://github.com/unoplatform/uno/issues/24489
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaUIKit)] // Flaky on Skia iOS/tvOS only - https://github.com/unoplatform/uno/issues/24489
 	public async Task When_Foreground_Changed_With_ShowAsMonochrome_True()
 	{
 		var bitmapIcon = new BitmapIcon

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_BitmapIcon.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_BitmapIcon.cs
@@ -107,6 +107,7 @@ public class Given_BitmapIcon
 #elif !__SKIA__
 	[Ignore("BitmapIcon flicker fix is Skia-specific - Image.skia.cs updates the surface brush color filter in place without reloading.")]
 #endif
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaUIKit)] // Flaky - https://github.com/unoplatform/uno/issues/24489
 	public async Task When_Foreground_Changed_With_ShowAsMonochrome_True()
 	{
 		var bitmapIcon = new BitmapIcon

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
@@ -99,6 +99,7 @@ public class Given_ScrollViewer_ScrollChaining
 	}
 
 	[TestMethod]
+	[Ignore("Flaky on all targets - https://github.com/unoplatform/uno/issues/24489")]
 	public async Task When_Chaining_Backwards_Then_Residual_Chains_To_Outer()
 	{
 		var (outer, inner, origin) = BuildNested();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
@@ -99,7 +99,7 @@ public class Given_ScrollViewer_ScrollChaining
 	}
 
 	[TestMethod]
-	[Ignore("Flaky on all targets - https://github.com/unoplatform/uno/issues/24489")]
+	[Ignore("Flaky on all targets, not one platform - https://github.com/unoplatform/uno/issues/24489")]
 	public async Task When_Chaining_Backwards_Then_Residual_Chains_To_Outer()
 	{
 		var (outer, inner, origin) = BuildNested();


### PR DESCRIPTION
**GitHub Issue:** #24489 (intentionally **not** auto-closed — that issue tracks fixing and re-enabling these tests)

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Five runtime tests fail intermittently and are adding noise to CI. All point at #24489, which tracks making them reliable and re-enabling them.

Four are disabled on **all targets** with `[Ignore]`:

| test | file |
|---|---|
| `Given_InputPane.When_Focused_TextBox_Has_Content_Below_Then_Scrolled_Above_Occlusion` | `Tests/Windows_UI_ViewManagement/Given_InputPane.cs` |
| `Given_InputPane.When_Focused_Element_Not_Occluded_Then_Centered_Content_Is_Not_Moved` | same |
| `Given_InputPane.When_Occluded_Field_In_Viewport_Sized_Content_Then_Scrolled_Above_Occlusion` | same |
| `Given_ScrollViewer_ScrollChaining.When_Chaining_Backwards_Then_Residual_Chains_To_Outer` | `Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs` |

One is flaky only on **Skia iOS / Skia tvOS** and is excluded just there:

| test | file |
|---|---|
| `Given_BitmapIcon.When_Foreground_Changed_With_ShowAsMonochrome_True` | `Tests/Windows_UI_Xaml_Controls/Icons/Given_BitmapIcon.cs` |

### "All targets" means all targets — there is no green configuration to keep them on

This is the part worth being explicit about, because two review passes read the `Include(Skia)` gate on the `Given_InputPane` tests as if it narrowed the *flakiness*. It doesn't — it narrows the *feature*:

- `RuntimeTestPlatforms.Skia` is `SkiaDesktop | SkiaWasm | SkiaMobile`, i.e. **every leg Uno runs runtime tests on** — Skia desktop (Windows, Linux, Linux Framebuffer, macOS), Skia WASM, Skia Android, Skia iOS and Skia tvOS. The only thing it excludes is WinAppSDK, where soft-keyboard occlusion scrolling is the OS's job and the test is meaningless. So "flaky on all targets" and "gated to Skia" are not in tension: the gate is the feature's platform scope, the `[Ignore]` is the flake's, and the flake's scope is *everything inside the gate*.
- `Given_ScrollViewer_ScrollChaining` isn't platform-gated at all (the class body is `#if HAS_UNO && UNO_HAS_MANAGED_SCROLL_PRESENTER`), and `When_Chaining_Backwards_Then_Residual_Chains_To_Outer` fails on every leg that compiles it.
- These are timing races on a dispatcher/layout round-trip, not platform-specific defects, so they do not stay green on any one host, renderer or OS. A `[PlatformCondition]` exclusion would therefore have to list every leg — which is what `[Ignore]` already is, spelled with one attribute instead of eight.

The contrast with the fifth test is the proof that the distinction is deliberate rather than lazy: `Given_BitmapIcon.When_Foreground_Changed_With_ShowAsMonochrome_True` **is** platform-specific, so it gets `[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaUIKit)]` and keeps running everywhere else. If the four could have been scoped that way, they would have been.

The `[Ignore]` reason now reads `"Flaky on all targets, not one platform"` so the same question doesn't get re-asked from the test report alone, and the `Given_BitmapIcon` exclusion comment now names Skia iOS/tvOS explicitly.

### Mechanics

The three `Given_InputPane` tests keep their existing `[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]`; `[Ignore]` supersedes it, so removing the `[Ignore]` later restores the original Skia-only gating with no further edit.

`Given_BitmapIcon` gets `[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaUIKit)]` (`SkiaUIKit == SkiaIOS | SkiaTvOS`) rather than a second `[Ignore]`: the method already carries a conditional `[Ignore]` for non-Skia and non-`RenderTargetBitmap` targets, and `IgnoreAttribute` is `AllowMultiple = false`, so a second one would be a duplicate-attribute compile error on those builds. `PlatformConditionAttribute` has no message parameter, which is why its reason lives in a trailing comment.

**Coverage retained:** the other three `Given_InputPane` tests (`When_OccludedRect_Set_Then_Focused_TextBox_Scrolled_Into_View`, `When_OccludedRect_Cleared_Then_ScrollViewer_Padding_Restored`, `When_App_Ensured_Focused_Element_In_View_Then_No_Pad_Is_Applied`) and the other five `Given_ScrollViewer_ScrollChaining` tests stay enabled, so the occlusion-pad and scroll-chaining features are not left uncovered. The BitmapIcon test still runs on every other Skia target, and `When_ShowAsMonochrome_False_Foreground_Change_Does_Not_Reload_Image` is untouched.

This is a tracked quarantine, not a deletion: #24489 is open, assigned, and records the per-test flakiness hypotheses (half-pixel geometry tolerances, viewport-height-dependent setup arithmetic, `WaitForIdle` vs. the `RequestUpdate` offset refresh) as starting points for the fix. They are labelled hypotheses precisely because the fix work hasn't happened yet — the decision to quarantine is about CI noise, and the root-cause analysis is what #24489 is for.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, this is a test-only change that disables tests
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjVqiGVHKGZyRLuy9SVMZi
