### PR TITLE
fix(android): Keep the compiled java in the .aar

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
+++ b/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
@@ -44,6 +44,17 @@
 		<AndroidJavaSource Include="..\Uno.UI.BindingHelper.Android\Uno\UI\UnoWebViewHandlerJavascriptInterface.java" />
 	</ItemGroup>
 
+	<!--
+	  _CompileBindingJava is what puts the compiled java in @(EmbeddedJar), and it only runs on the
+	  build path. The pack pass reaches _CreateAar through ResolveReferences instead, so it rewrites
+	  the .aar with no jar in it. Re-declare the jar so every pass produces the same .aar.
+	-->
+	<Target Name="_UnoKeepBindingJarInAar" BeforeTargets="_CreateAarCache" Condition="Exists('$(_AndroidIntermediateBindingClassesZip)')">
+		<ItemGroup>
+			<EmbeddedJar Include="$(_AndroidIntermediateBindingClassesZip)" Condition="'@(EmbeddedJar)' == ''" />
+		</ItemGroup>
+	</Target>
+
 	<ItemGroup>
 		<PackageReference Include="SkiaSharp" />
 		<PackageReference Include="HarfBuzzSharp" />


### PR DESCRIPTION
**GitHub Issue:** closes #24493

## PR Type:

🐞 Bugfix

## What changed? 🚀

`lib/net10.0-android36.0/Uno.UI.Runtime.Skia.Android.aar` in the `Uno.WinUI.Runtime.Skia.Android` package contained **only** `proguard.txt` — no `libs/*.jar`. `Uno/UI/UnoWebViewHandlerJavascriptInterface.class` therefore never reached javac's classpath in consuming apps, and every Android head died compiling the Java Callable Wrapper for `UnoWebViewHandler`:

```
UnoWebViewHandler.java:5: error: package Uno.UI does not exist
        extends Uno.UI.UnoWebViewHandlerJavascriptInterface
```

`_CompileBindingJava` is what adds the compiled java to `@(EmbeddedJar)`, and it does so **inside the target**, which sits only on the build path (`_AndroidBuildDependsOn`). The project is built twice in one invocation: the second instance is the NuGet pack pass (`BuildProjectReferences=false`), which reaches `_CreateAar` through `ResolveReferences → UpdateAndroidResources → _UpdateAndroidResourcesDependsOn` and never runs `_CompileBindingJava`. `@(EmbeddedJar)` is empty there, `_CreateAarCache` hashes a different input set, and `_CreateAar` reruns and overwrites the good aar with a jar-less one.

This re-declares the jar in a target that every pass reaches, so the aar is identical whichever path builds it.

### Not a 7.0 regression

The aar has been jar-less since c0a9b6ae60b4a842205adf93c85403823085e071 (2025-08-06) moved the java to `@(AndroidJavaSource)` — `uno.winui.runtime.skia.android` **6.7.65**'s net10.0-android36.0 aar is `['proguard.txt']` too. It was masked because `uno.winui` 6.x still shipped Android TFMs carrying `Uno.UI.BindingHelper.Android.aar`, whose jar holds the *same* class. Uno 7.0 dropped the Android TFMs from `uno.winui`, so nothing supplies it any more.

`Uno.UI.BindingHelper.Android` survives the identical SDK behaviour because it is packed by the hand-authored `build/nuget/Uno.WinUI.nuspec`, which copies the aar out of `bin/Release/<tfm>/`. No `GeneratePackageOnBuild` → no pack pass → `_CreateAar` is never re-entered on it.

### Minimal trigger

Reproduced standalone in a ~20-line project (`AndroidJavaSource` + a `net10.0-android` class library):

| ingredients | compiled java in the aar |
|---|---|
| `AndroidJavaSource` alone | ✅ present |
| + `GeneratePackageOnBuild` | ✅ present |
| + one AndroidX `PackageReference` | ❌ **dropped** |

`GeneratePackageOnBuild` alone is not enough — something else must feed `_CreateAarInputs`. The AndroidX package contributes a `proguard.txt`; without it the item list is empty and MSBuild skips `_CreateAar` in the second pass ("skipped because it has no inputs"). That is why `Uno.Foundation` and `Uno.UI.Dispatching` escape in the same build, while `Uno.UI.Runtime.Skia.Android` (which references `Xamarin.AndroidX.AppCompat` and `Xamarin.AndroidX.DocumentFile`) does not.

### Why `net11.0-android37.0` was unaffected

The .NET 11 Android SDK already fixes this, by moving `_CreateAar` off the reference-resolution path and onto the pack path:

```diff
--- Microsoft.Android.Sdk.BuildOrder.targets   36.1.69                  (.NET 10)
+++ Microsoft.Android.Sdk.BuildOrder.targets   37.0.0-preview.7.2131    (.NET 11)
     <_UpdateAndroidResourcesDependsOn>
       ...
       _UpdateAndroidResgen;
-      _CreateAar;
     </_UpdateAndroidResourcesDependsOn>

     <_IncludeAarInNuGetPackageDependsOn>
       _BuildAndroidGradleProjects;
       _CategorizeAndroidLibraries;
+      _CreateAar;
     </_IncludeAarInNuGetPackageDependsOn>
```

`Xamarin.Android.Javac.targets` is otherwise unchanged between the two (one unrelated `AdditionalStubSourceDirectories` parameter), so `_CompileBindingJava` still contributes `@(EmbeddedJar)` from inside the target — 37.x simply no longer re-enters `_CreateAar` where that item list is empty.

**Implication for this change:** once the repo's Android SDK reaches 37.x, the target below becomes a no-op — its `Condition` still holds but `@(EmbeddedJar)` is already populated, so it adds nothing. It is safe to keep and safe to delete at that point.

## Verification

`dotnet build src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj -c Release -p:UnoTargetFrameworkOverride=net10.0-android`, then inspecting the outputs:

| | `bin/Release/net10.0-android/*.aar` | `lib/net10.0-android36.0/*.aar` in the nupkg |
|---|---|---|
| before | `['proguard.txt']` | `['proguard.txt']` |
| after | `['libs/<hash>.jar', 'proguard.txt']` | `['libs/<hash>.jar', 'proguard.txt']` |

with `libs/<hash>.jar` containing `Uno/UI/UnoWebViewHandlerJavascriptInterface.class`.

Note that CI cannot catch a regression here: the sample heads in this repo consume `Uno.UI.Runtime.Skia.Android` through a `ProjectReference`, not through the produced package, which is exactly why this shipped unnoticed. The check above is on the packaged artifact.

Not verified: no Android app was launched from the fixed package — the failure was a compile-time classpath one.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
  > Packaging-only fix, and not observable through a `ProjectReference` — it would need a check on the produced nupkg.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbHmxnFUWzjgeBQgdZGC1T
