### PR TITLE
fix: Refresh NavigationView ancestor selection

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/NavigationView/NavigationViewTests.AncestorSelection.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/NavigationView/NavigationViewTests.AncestorSelection.cs
@@ -8,7 +8,9 @@ using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;
 using Private.Infrastructure;
+using Uno.UI.RuntimeTests;
 using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
 
 namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests;
 
@@ -16,6 +18,7 @@ public partial class NavigationViewTests
 {
 	[TestMethod]
 	[RunsOnUIThread]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24508")]
 	public async Task When_SelectedChildMovesBetweenParents_OnlyCurrentAncestorsStaySelected()
 	{
 		var selected = new AncestorSelectionNode("Selected");
@@ -49,6 +52,7 @@ public partial class NavigationViewTests
 
 			source.Children.Remove(selected);
 			destination.Children.Add(selected);
+			await WindowHelper.WaitForIdle();
 			navigation.SelectedItem = selected;
 			await WindowHelper.WaitForIdle();
 
@@ -81,6 +85,7 @@ public partial class NavigationViewTests
 
 	[TestMethod]
 	[RunsOnUIThread]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24508")]
 	[DataRow(false)]
 	[DataRow(true)]
 	public async Task When_AncestorIndexChanges_DeselectClearsOriginalAncestor(bool changePaneMode)
@@ -147,6 +152,7 @@ public partial class NavigationViewTests
 
 	[TestMethod]
 	[RunsOnUIThread]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24508")]
 	public async Task When_SelectedChildMovesIntoCollapsedParent_SelectionFollowsItsNewAncestor()
 	{
 		var selected = new AncestorSelectionNode("Selected");

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/NavigationView/NavigationViewTests.AncestorSelection.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/NavigationView/NavigationViewTests.AncestorSelection.cs
@@ -1,0 +1,201 @@
+#nullable enable
+
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests;
+
+public partial class NavigationViewTests
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_SelectedChildMovesBetweenParents_OnlyCurrentAncestorsStaySelected()
+	{
+		var selected = new AncestorSelectionNode("Selected");
+		var source = new AncestorSelectionNode("Source");
+		source.Children.Add(selected);
+		source.Children.Add(new AncestorSelectionNode("Remaining"));
+		var destination = new AncestorSelectionNode("Destination");
+		destination.Children.Add(new AncestorSelectionNode("Existing"));
+		var navigation = new NavigationView
+		{
+			PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+			IsPaneOpen = true,
+			Width = 600,
+			Height = 500,
+			MenuItemsSource = new ObservableCollection<AncestorSelectionNode> { source, destination },
+			MenuItemTemplate = (DataTemplate)XamlReader.Load("""
+				<DataTemplate xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+					<NavigationViewItem Content="{Binding Title}" MenuItemsSource="{Binding Children}" IsExpanded="True" />
+				</DataTemplate>
+				""")
+		};
+
+		try
+		{
+			await UITestHelper.Load(navigation);
+			navigation.SelectedItem = selected;
+			await WindowHelper.WaitForIdle();
+			var sourceContainer = (NavigationViewItem)navigation.ContainerFromMenuItem(source);
+			var destinationContainer = (NavigationViewItem)navigation.ContainerFromMenuItem(destination);
+			Assert.IsTrue(sourceContainer.IsChildSelected);
+
+			source.Children.Remove(selected);
+			destination.Children.Add(selected);
+			navigation.SelectedItem = selected;
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreSame(selected, navigation.SelectedItem);
+			var selectedContainer = (NavigationViewItem)navigation.ContainerFromMenuItem(selected);
+			Assert.IsFalse(sourceContainer.IsChildSelected);
+			Assert.IsTrue(destinationContainer.IsChildSelected);
+			Assert.IsFalse(selectedContainer.IsChildSelected);
+
+			var peer = FrameworkElementAutomationPeer.CreatePeerForElement(sourceContainer);
+			((IExpandCollapseProvider)peer.GetPattern(PatternInterface.ExpandCollapse)).Collapse();
+			await WindowHelper.WaitForIdle();
+			Assert.AreSame(selected, navigation.SelectedItem);
+			Assert.IsTrue(selectedContainer.IsSelected);
+			Assert.IsFalse(sourceContainer.IsChildSelected);
+			Assert.IsTrue(destinationContainer.IsChildSelected);
+
+			navigation.IsPaneOpen = false;
+			await WindowHelper.WaitForIdle();
+			navigation.IsPaneOpen = true;
+			await WindowHelper.WaitForIdle();
+			Assert.IsFalse(sourceContainer.IsChildSelected);
+			Assert.IsTrue(destinationContainer.IsChildSelected);
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[DataRow(false)]
+	[DataRow(true)]
+	public async Task When_AncestorIndexChanges_DeselectClearsOriginalAncestor(bool changePaneMode)
+	{
+		var selected = new NavigationViewItem { Content = "Selected" };
+		var innerParent = new NavigationViewItem { Content = "Inner parent", IsExpanded = true };
+		innerParent.MenuItems.Add(selected);
+		var parent = new NavigationViewItem { Content = "Parent", IsExpanded = true };
+		parent.MenuItems.Add(innerParent);
+		var topLevel = new NavigationViewItem { Content = "Top level" };
+		var roots = new ObservableCollection<object> { parent, topLevel };
+		var navigation = new NavigationView
+		{
+			PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+			IsPaneOpen = true,
+			Width = 600,
+			Height = 500,
+			MenuItemsSource = roots
+		};
+
+		try
+		{
+			await UITestHelper.Load(navigation);
+			navigation.SelectedItem = selected;
+			await WindowHelper.WaitForIdle();
+
+			if (changePaneMode)
+			{
+				navigation.PaneDisplayMode = NavigationViewPaneDisplayMode.LeftCompact;
+				navigation.IsPaneOpen = true;
+				await WindowHelper.WaitForIdle();
+				Assert.IsTrue(parent.IsChildSelected);
+				Assert.IsTrue(innerParent.IsChildSelected);
+			}
+
+			roots.Insert(0, new NavigationViewItem { Content = "Inserted" });
+			await WindowHelper.WaitForIdle();
+			Assert.AreSame(selected, navigation.SelectedItem);
+			Assert.IsTrue(parent.IsChildSelected);
+			Assert.IsTrue(innerParent.IsChildSelected);
+
+			navigation.SelectedItem = topLevel;
+			await WindowHelper.WaitForIdle();
+			Assert.IsFalse(parent.IsChildSelected);
+			Assert.IsFalse(innerParent.IsChildSelected);
+			Assert.IsFalse(topLevel.IsChildSelected);
+			Assert.IsFalse(selected.IsChildSelected);
+			Assert.IsTrue(topLevel.IsSelected);
+
+			navigation.SelectedItem = selected;
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(parent.IsChildSelected);
+			Assert.IsTrue(innerParent.IsChildSelected);
+			navigation.SelectedItem = null;
+			await WindowHelper.WaitForIdle();
+			Assert.IsFalse(parent.IsChildSelected);
+			Assert.IsFalse(innerParent.IsChildSelected);
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_SelectedChildMovesIntoCollapsedParent_SelectionFollowsItsNewAncestor()
+	{
+		var selected = new AncestorSelectionNode("Selected");
+		var source = new AncestorSelectionNode("Source");
+		var destination = new AncestorSelectionNode("Destination");
+		source.Children.Add(selected);
+		source.Children.Add(new AncestorSelectionNode("Remaining"));
+		destination.Children.Add(new AncestorSelectionNode("Existing"));
+		var navigation = new NavigationView
+		{
+			PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+			IsPaneOpen = true,
+			Width = 600,
+			Height = 500,
+			MenuItemsSource = new ObservableCollection<AncestorSelectionNode> { source, destination },
+			MenuItemTemplate = (DataTemplate)XamlReader.Load("""
+				<DataTemplate xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+					<NavigationViewItem Content="{Binding Title}" MenuItemsSource="{Binding Children}" IsExpanded="True" />
+				</DataTemplate>
+				""")
+		};
+
+		try
+		{
+			await UITestHelper.Load(navigation);
+			navigation.SelectedItem = selected;
+			await WindowHelper.WaitForIdle();
+			var sourceContainer = (NavigationViewItem)navigation.ContainerFromMenuItem(source);
+			var destinationContainer = (NavigationViewItem)navigation.ContainerFromMenuItem(destination);
+			destinationContainer.IsExpanded = false;
+			await WindowHelper.WaitForIdle();
+			source.Children.Remove(selected);
+			destination.Children.Add(selected);
+			navigation.SelectedItem = selected;
+			await WindowHelper.WaitForIdle();
+			Assert.AreSame(selected, navigation.SelectedItem);
+			Assert.IsFalse(sourceContainer.IsChildSelected);
+			Assert.IsTrue(destinationContainer.IsChildSelected);
+			Assert.IsFalse(destinationContainer.IsExpanded);
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	public sealed class AncestorSelectionNode(string title)
+	{
+		public string Title { get; } = title;
+		public ObservableCollection<AncestorSelectionNode> Children { get; } = new();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Header.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Header.cs
@@ -164,6 +164,7 @@ public partial class NavigationView
 	private TopNavigationViewDataProvider m_topDataProvider;
 
 	private SelectionModel m_selectionModel = new();
+	private readonly List<global::System.WeakReference<NavigationViewItem>> m_selectedAncestors = new();
 	private IList<object> m_selectionModelSource;
 
 	private ItemsSourceView m_menuItemsSource;

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -276,6 +276,11 @@ public partial class NavigationView : ContentControl
 	private void OnSelectionModelSelectionChanged(SelectionModel selectionModel, SelectionModelSelectionChangedEventArgs e)
 	{
 		var selectedItem = selectionModel.SelectedItem;
+		if (m_appliedTemplate && (selectedItem is null || selectedItem != SelectedItem))
+		{
+			// An index-only change preserves ancestor identities and may precede repeater index updates.
+			UpdateIsChildSelected(selectionModel.SelectedIndex);
+		}
 
 		// Ignore this callback if:
 		// 1. the SelectedItem property of NavigationView is already set to the item
@@ -1032,7 +1037,7 @@ public partial class NavigationView : ContentControl
 					}
 					else if (!IsPaneOpen && indexPath.GetSize() == 0)
 					{
-						UpdateIsChildSelected(indexPathFromModel, null); // Update IsChildSelected Property of Parent Chain
+						UpdateIsChildSelected(null); // Update IsChildSelected Property of Parent Chain
 						if (m_prevIndicator == null && m_nextIndicator == null && m_activeIndicator != null)
 						{
 							// Remove selection indication if we are not in the middle of an ongoing animation
@@ -1353,6 +1358,7 @@ public partial class NavigationView : ContentControl
 				SetNavigationViewItemRevokers(nvi);
 
 				var item = MenuItemFromContainer(nvi);
+				UpdateIsChildSelectedForContainer(nvi);
 
 				if (SelectedItem == item && IsVisible(nvi))
 				{
@@ -1399,6 +1405,11 @@ public partial class NavigationView : ContentControl
 	{
 		if (args.Element is NavigationViewItemBase nvib)
 		{
+			if (nvib is NavigationViewItem item)
+			{
+				SetIsChildSelected(item, false);
+			}
+
 			var nvibImpl = nvib;
 			nvibImpl.Depth = 0;
 			nvibImpl.IsTopLevelItem = false;
@@ -2654,37 +2665,53 @@ public partial class NavigationView : ContentControl
 
 	private void UpdateSelectionModelSelection(IndexPath ip)
 	{
-		var prevIndexPath = m_selectionModel.SelectedIndex;
 		m_selectionModel.SelectAt(ip);
-		UpdateIsChildSelected(prevIndexPath, ip);
+		UpdateIsChildSelected(m_selectionModel.SelectedIndex);
 	}
 
-	private void UpdateIsChildSelected(IndexPath prevIP, IndexPath nextIP)
+	private void UpdateIsChildSelected(IndexPath nextIP)
 	{
-		if (prevIP != null && prevIP.GetSize() > 0)
+		var selectedItem = m_selectionModel.SelectedItem;
+		// The old path may already refer to different rows after a collection mutation.
+		while (m_selectedAncestors.Count > 0)
 		{
-			UpdateIsChildSelectedForIndexPath(prevIP, false /*isChildSelected*/);
+			var index = m_selectedAncestors.Count - 1;
+			var ancestor = m_selectedAncestors[index];
+			m_selectedAncestors.RemoveAt(index);
+			if (ancestor.TryGetTarget(out var container))
+			{
+				container.IsChildSelected = false;
+			}
+			if (m_selectionModel.SelectedItem != selectedItem)
+			{
+				return;
+			}
 		}
 
-		if (nextIP != null && nextIP.GetSize() > 0)
+		if (nextIP != null && nextIP.GetSize() > 2)
 		{
-			UpdateIsChildSelectedForIndexPath(nextIP, true /*isChildSelected*/);
+			UpdateIsChildSelectedForIndexPath(nextIP);
 		}
 	}
 
-	private void UpdateIsChildSelectedForIndexPath(IndexPath ip, bool isChildSelected)
+	private void UpdateIsChildSelectedForIndexPath(IndexPath ip)
 	{
+		var selectedItem = m_selectionModel.SelectedItem;
 		// Update the isChildSelected property for every container on the IndexPath (with the exception of the actual container pointed to by the indexpath)
 		var container = GetContainerForIndex(ip.GetAt(1), ip.GetAt(0) == c_footerMenuBlockIndex /*inFooter*/);
 		// first index is fo mainmenu or footer
 		// second is index of item in mainmenu or footer
 		// next in menuitem children
 		var index = 2;
-		while (container != null)
+		while (container != null && index < ip.GetSize())
 		{
 			if (container is NavigationViewItem nvi)
 			{
-				nvi.IsChildSelected = isChildSelected;
+				SetIsChildSelected(nvi, true);
+				if (m_selectionModel.SelectedItem != selectedItem)
+				{
+					return;
+				}
 				var nextIR = nvi.GetRepeater();
 				if (nextIR != null)
 				{
@@ -2698,6 +2725,34 @@ public partial class NavigationView : ContentControl
 			}
 			container = null;
 		}
+	}
+
+	private void UpdateIsChildSelectedForContainer(NavigationViewItem container)
+	{
+		var selectedPath = m_selectionModel.SelectedIndex;
+		var containerPath = GetIndexPathForContainer(container);
+		var isAncestor = selectedPath != null && containerPath.GetSize() > 1 && containerPath.GetSize() < selectedPath.GetSize();
+		for (var index = 0; isAncestor && index < containerPath.GetSize(); index++)
+		{
+			isAncestor = containerPath.GetAt(index) == selectedPath.GetAt(index);
+		}
+		SetIsChildSelected(container, isAncestor);
+	}
+
+	private void SetIsChildSelected(NavigationViewItem container, bool isChildSelected)
+	{
+		for (var index = m_selectedAncestors.Count - 1; index >= 0; index--)
+		{
+			if (!m_selectedAncestors[index].TryGetTarget(out var ancestor) || ancestor == container)
+			{
+				m_selectedAncestors.RemoveAt(index);
+			}
+		}
+		if (isChildSelected)
+		{
+			m_selectedAncestors.Add(new global::System.WeakReference<NavigationViewItem>(container));
+		}
+		container.IsChildSelected = isChildSelected;
 	}
 
 	private void RaiseItemInvoked(


### PR DESCRIPTION
**GitHub Issue:** closes #24508

## PR Type:

🐞 Bugfix

## What changed? 🚀

Moving a selected child between ObservableCollection groups can leave its former ancestors marked IsChildSelected. Collapsing an unrelated former parent then takes the selection indicator even though SelectedItem still identifies the moved leaf.

This Uno-specific correction tracks actual ancestor containers instead of resolving a stale previous index path after collection changes. It clears state on recycling/deselection, projects it for prepared containers, preserves ancestor identity on index-only changes, and excludes the selected leaf itself. Ancestor entries are removed before invoking dependency-property callbacks so synchronous changes cannot invalidate enumeration.

Follow-up 415d7c743ccc999cc62cd2cfc9b8eab090340d9d addresses the requested changes: after refreshing ancestors, the outer selection callback stops if a synchronous property callback superseded its captured selection. Real runtime coverage includes both a root fallback and a nested fallback chosen by that callback.

## Validation

**Code review:** reviewed ownership, reentrancy, API contracts, security, performance, operability and test quality through the repository's eight-lens panel. The current guard uses final selected-item identity, matching the helper's contract; this is not a claim of generation-level intent tracking.

**Compile:** full source SamplesApp Release/net10.0-desktop built on Linux ARM64 with .NET SDK 10.0.400. Local analyzers were disabled using UnoFastDevBuild. The final build succeeded; existing MSB4011 duplicate-import warnings appear during initial project evaluation even though the build summary reports zero warnings. The previous nullable automation-provider conversion in this PR's runtime test was fixed with a provider-presence assertion.

**Runtime:** four methods / six parameterized executions from NavigationViewTests.AncestorSelection.cs passed twice on the real Skia X11 control tree, with zero failures, skips or retries. Coverage: data-bound reparenting; a collapsed destination; three-level index shifts with/without a pane-mode transition; clearing selection; synchronous ancestor-callback reselection to root and nested fallback items.

The compact-mode fixture respects native leaf auto-close: it reopens the pane before reselecting an explicit nested item and before checking its realized ancestor containers. Selected identity and the top-level ancestor are checked before that second reopening. All original ancestor assertions remain. This is not coverage of selecting a detached descendant with the pane kept closed.

**Negative control:** removing the five-line outer callback guard makes both new fallback rows fail at the retained-selection assertion. Restoring it makes both pass. Earlier development comparisons at Uno 6.7.103 also reproduced the original application indicator defect with the published assembly and passed with the equivalent source fix; those comparisons are not published-package validation.

Reproduction:

```bash
dotnet build src/SamplesApp/SamplesApp/SamplesApp.csproj -c Release -f net10.0-desktop -p:UnoFastDevBuild=true -p:UnoTargetFrameworkOverride=net10.0-desktop -p:UseSharedCompilation=false -m:1 -nr:false
# Base64-encode the fully-qualified method filter as required by the runtime-tests skill.
export UITEST_RUNTIME_TESTS_FILTER=$(printf %s Microsoft.UI.Xaml.Tests.MUXControls.ApiTests.NavigationViewTests.When_AncestorDeselectionCallbackSelectsFallback_NewSelectionIsPreserved | base64 -w0)
cd src/SamplesApp/SamplesApp/bin/Release/net10.0-desktop
xvfb-run -a dotnet SamplesApp.dll --runtime-tests=results.xml
```

Evidence on the validation host: /tmp/pr24509-final3/results.xml, /tmp/pr24509-repeat/results.xml, /tmp/pr24509-negative/results.xml, /tmp/pr24509-final3-build.log. The build process alone used a 3 GiB GC heap cap, workstation GC and GCConserveMemory=9 to limit host pressure; these settings did not change source or the test app's runtime configuration.

**Pending:** maintainer re-review, official upstream runtime/strict CI, and native WinUI behavioral parity. The MUX tests are excluded by the Windows runtime project, so its ordinary job must not be counted as execution of these cases. The Microsoft implementation still uses the old index-path algorithm: this change is intentionally Uno-specific, not a literal port.

Consumers must wait for a published package containing the fix. The downstream application PR salmonloop/salmon-egg#214 remains Draft and must not substitute a development DLL or disable its failing GUI gate to appear green.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests for the bug and adjacent lifecycle cases.
- [ ] 📚 Docs have been added/updated following the documentation template (no public API changes).
- [ ] 🖼️ Validated PR Screenshots Compare Test Run results.
- [x] ❗ Contains **NO** breaking changes.
- [ ] 👀 Reviewed 2 other open pull requests (optional).
